### PR TITLE
[임송이] 카드 컴포넌트

### DIFF
--- a/src/components/cards/IncomingRequestCard.stories.tsx
+++ b/src/components/cards/IncomingRequestCard.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import IncomingRequestCard from "./IncomingRequestCard";
+import { action } from "@storybook/addon-actions";
+
+const meta = {
+  title: "Cards/IncomingRequestCard",
+  component: IncomingRequestCard,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof IncomingRequestCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockData = {
+  id: 100,
+  requestDate: "2024-03-17T12:00:00.000Z",
+  service: 0, // 가정이사
+  isDesignated: true,
+  name: "김일반",
+  movingDate: "2024-11-30T12:00:00.000Z",
+  pickupAddress: "서울특별시 강남구 역삼동 123-456",
+  dropOffAddress: "서울특별시 서초구 서초동 789-012",
+  isCompleted: false,
+  isRejected: false,
+};
+
+// 스토리북 액션 생성
+const handlePrimaryClick = action("견적 보내기 클릭");
+const handleOutlinedClick = action("반려 클릭");
+
+export const Default: Story = {
+  args: {
+    data: mockData,
+    onPrimaryClick: handlePrimaryClick,
+    onOutlinedClick: handleOutlinedClick,
+  },
+};
+
+export const WithDesignatedService: Story = {
+  args: {
+    data: {
+      ...mockData,
+      isDesignated: true,
+    },
+    onPrimaryClick: handlePrimaryClick,
+    onOutlinedClick: handleOutlinedClick,
+  },
+};
+
+export const WithOfficeMoving: Story = {
+  args: {
+    data: {
+      ...mockData,
+      service: 1, // 사무실 이사
+      isDesignated: false,
+    },
+    onPrimaryClick: handlePrimaryClick,
+    onOutlinedClick: handleOutlinedClick,
+  },
+};
+
+export const WithLongAddress: Story = {
+  args: {
+    data: {
+      ...mockData,
+      pickupAddress: "서울특별시 강남구 역삼동 123-456 강남파이낸스센터 63층",
+      dropOffAddress:
+        "서울특별시 서초구 서초동 789-012 강남역 최고 오피스텔 1동 1004호",
+    },
+    onPrimaryClick: handlePrimaryClick,
+    onOutlinedClick: handleOutlinedClick,
+  },
+};

--- a/src/components/cards/IncomingRequestCard.stories.tsx
+++ b/src/components/cards/IncomingRequestCard.stories.tsx
@@ -24,7 +24,6 @@ const mockData = {
   pickupAddress: "서울특별시 강남구 역삼동 123-456",
   dropOffAddress: "서울특별시 서초구 서초동 789-012",
   isCompleted: false,
-  isRejected: false,
 };
 
 // 스토리북 액션 생성

--- a/src/components/cards/IncomingRequestCard.tsx
+++ b/src/components/cards/IncomingRequestCard.tsx
@@ -8,7 +8,6 @@ import QuoteDetails from "../common/card/QuoteDetails";
 interface RequestQuoteData extends QuoteDetailsData {
   id: number;
   isCompleted: boolean;
-  isRejected: boolean;
 }
 
 interface IncomingRequestCardProps {

--- a/src/components/cards/IncomingRequestCard.tsx
+++ b/src/components/cards/IncomingRequestCard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import CardContainer from "../common/card/CardContainer";
+import Button from "../common/Button";
+import { type QuoteDetailsData } from "@/types/mover";
+import QuoteDetails from "../common/card/QuoteDetails";
+
+interface RequestQuoteData extends QuoteDetailsData {
+  id: number;
+  isCompleted: boolean;
+  isRejected: boolean;
+}
+
+interface IncomingRequestCardProps {
+  data: RequestQuoteData;
+  className?: string;
+  onPrimaryClick: () => void;
+  onOutlinedClick: () => void;
+}
+
+const styles = {
+  buttonContainer: "flex flex-col gap-2 tablet:flex-row w-full",
+};
+
+const IncomingRequestCard = ({
+  data,
+  className,
+  onPrimaryClick,
+  onOutlinedClick,
+}: IncomingRequestCardProps) => {
+  return (
+    <CardContainer>
+      <QuoteDetails data={data} />
+      <div className={styles.buttonContainer}>
+        <Button withIcon width="100%" onClick={onPrimaryClick}>
+          견적 보내기
+        </Button>
+        <Button variant="outlined" width="100%" onClick={onOutlinedClick}>
+          반려
+        </Button>
+      </div>
+    </CardContainer>
+  );
+};
+
+export default IncomingRequestCard;

--- a/src/components/cards/MoverProfileCard.tsx
+++ b/src/components/cards/MoverProfileCard.tsx
@@ -7,7 +7,7 @@ import { type ProfileData, type FullMoverData } from "@/types/mover";
 import { cva } from "class-variance-authority";
 import Button from "../common/Button";
 import cn from "@/config/clsx";
-import { getRegionText } from "@/utils/utilFunctions";
+import { getRegionText, getServiceText } from "@/utils/utilFunctions";
 
 interface MoverProfileCardProps {
   data: FullMoverData & ProfileData;
@@ -51,9 +51,9 @@ const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
               <div className="flex items-center gap-1">
                 <GrayLabel>제공 서비스</GrayLabel>
                 <div className={styles.text}>
-                  {data.services.map((service) => (
-                    <p key={service}>{service}</p>
-                  ))}
+                  {data.services
+                    .map((service) => getServiceText(service))
+                    .join(", ")}
                 </div>
               </div>
               <div className={styles.info}>

--- a/src/components/cards/MoverProfileCard.tsx
+++ b/src/components/cards/MoverProfileCard.tsx
@@ -14,15 +14,13 @@ interface MoverProfileCardProps {
   className?: string;
 }
 
-const moverProfileCardStyles = cva(
-  "flex flex-col border-solid border-[0.5px] gap-4 border-grayscale-100 bg-bg-100 rounded-[16px] py-4 px-3.5 min-w-[327px] pc:p-6 gap-6"
-);
-
-const innerContainerStyles = cva(
-  "flex flex-col border-solid border-line-100 border-[1px] shadow-border rounded-[16px] gap-3.5 p-2.5 pc:flex-row pc:items-center pc:py-[26px] pc:px-[18px]"
-);
-
 const styles = {
+  container: cva(
+    "flex flex-col border-solid border-[0.5px] gap-4 border-grayscale-100 bg-bg-100 rounded-[16px] py-4 px-3.5 min-w-[327px] pc:p-6 gap-6"
+  ),
+  innerContainer: cva(
+    "flex flex-col border-solid border-line-100 border-[1px] shadow-border rounded-[16px] gap-3.5 p-2.5 pc:flex-row pc:items-center pc:py-[26px] pc:px-[18px]"
+  ),
   info: "flex items-center gap-1",
   text: "flex gap-1 text-md font-medium pc:text-2lg",
   button: "w-full tablet:w-[298px]",
@@ -32,7 +30,7 @@ const styles = {
 const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
   return (
     <section className={cn("flex flex-col gap-4 relative", className)}>
-      <section className={moverProfileCardStyles()}>
+      <section className={styles.container()}>
         <div className="flex items-center gap-4">
           <ProfileImage imgUrl={data.imageUrl} className="pc:hidden" />
           <div className="flex flex-col gap-1 pc:gap-2">
@@ -43,7 +41,7 @@ const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
           </div>
         </div>
 
-        <div className={cn(innerContainerStyles(), "pc:relative")}>
+        <div className={cn(styles.innerContainer(), "pc:relative")}>
           <ProfileImage imgUrl={data.imageUrl} className="hidden pc:block" />
           <div className="flex flex-col gap-3.5 pc:gap-4">
             <MoverExperience data={data} />

--- a/src/components/cards/MoverProfileCard.tsx
+++ b/src/components/cards/MoverProfileCard.tsx
@@ -12,6 +12,8 @@ import TextWithGrayLabel from "../common/card/TextWithGrayLabel";
 interface MoverProfileCardProps {
   data: FullMoverData & ProfileData;
   className?: string;
+  onPrimaryClick?: () => void;
+  onOutlinedClick?: () => void;
 }
 
 const styles = {
@@ -24,9 +26,21 @@ const styles = {
   info: "flex items-center gap-1",
   button: "w-full tablet:w-[298px]",
   buttonContainer: "flex flex-wrap gap-2 pc:absolute pc:top-6 pc:right-6",
+  topContainer: "flex items-center gap-4",
+  nameContainer: "flex gap-2",
+  nickname: "text-md font-medium text-grayscale-500 pc:text-lg",
+  name: "text-lg font-semibold pc:text-2lg",
+  topLeftContainer: "flex flex-col gap-1 pc:gap-2",
+  introduction: "text-md font-regular text-grayscale-400 pc:text-lg",
+  labelContainer: "flex flex-col gap-1 pc:gap-2 pc:flex-row",
 };
 
-const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
+const MoverProfileCard = ({
+  data,
+  className,
+  onPrimaryClick,
+  onOutlinedClick,
+}: MoverProfileCardProps) => {
   const serviceText = data.services
     .map((service) => getServiceText(service))
     .join(", ");
@@ -35,13 +49,15 @@ const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
   return (
     <section className={cn("flex flex-col gap-4 relative", className)}>
       <section className={styles.container()}>
-        <div className="flex items-center gap-4">
+        <div className={styles.topContainer}>
           <ProfileImage imgUrl={data.imageUrl} className="pc:hidden" />
-          <div className="flex flex-col gap-1 pc:gap-2">
-            <p className="text-lg font-semibold pc:text-2lg">{data.name}</p>
-            <p className="text-md font-regular pc:text-lg text-grayscale-400 truncate">
-              {data.introduction}
-            </p>
+          <div className={styles.topLeftContainer}>
+            <span className={styles.nameContainer}>
+              <p className={styles.name}>{data.name}</p>
+              <p className={styles.nickname}>{data.nickname}</p>
+            </span>
+
+            <p className={styles.introduction}>{data.introduction}</p>
           </div>
         </div>
 
@@ -50,7 +66,7 @@ const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
           <div className="flex flex-col gap-3.5 pc:gap-4">
             <MoverExperience data={data} />
 
-            <div className="flex flex-col gap-1 pc:gap-2 pc:flex-row">
+            <div className={styles.labelContainer}>
               <TextWithGrayLabel
                 variant="border"
                 label="제공 서비스"
@@ -67,11 +83,21 @@ const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
       </section>
 
       <div className={styles.buttonContainer}>
-        <Button variant="primary" withIcon className={styles.button}>
+        <Button
+          variant="primary"
+          withIcon
+          className={styles.button}
+          onClick={onPrimaryClick}
+        >
           내 프로필 수정
         </Button>
 
-        <Button variant="gray" withIcon className={styles.button}>
+        <Button
+          variant="gray"
+          withIcon
+          className={styles.button}
+          onClick={onOutlinedClick}
+        >
           기본 정보 수정
         </Button>
       </div>

--- a/src/components/cards/MoverProfileCard.tsx
+++ b/src/components/cards/MoverProfileCard.tsx
@@ -2,12 +2,12 @@
 
 import MoverExperience from "../common/card/MoverExperience";
 import ProfileImage from "../common/card/ProfileImage";
-import GrayLabel from "../common/card/GrayLabel";
 import { type ProfileData, type FullMoverData } from "@/types/mover";
 import { cva } from "class-variance-authority";
 import Button from "../common/Button";
 import cn from "@/config/clsx";
 import { getRegionText, getServiceText } from "@/utils/utilFunctions";
+import TextWithGrayLabel from "../common/card/TextWithGrayLabel";
 
 interface MoverProfileCardProps {
   data: FullMoverData & ProfileData;
@@ -22,12 +22,16 @@ const styles = {
     "flex flex-col border-solid border-line-100 border-[1px] shadow-border rounded-[16px] gap-3.5 p-2.5 pc:flex-row pc:items-center pc:py-[26px] pc:px-[18px]"
   ),
   info: "flex items-center gap-1",
-  text: "flex gap-1 text-md font-medium pc:text-2lg",
   button: "w-full tablet:w-[298px]",
   buttonContainer: "flex flex-wrap gap-2 pc:absolute pc:top-6 pc:right-6",
 };
 
 const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
+  const serviceText = data.services
+    .map((service) => getServiceText(service))
+    .join(", ");
+  const regionText = data.regions.map((code) => getRegionText(code)).join(", ");
+
   return (
     <section className={cn("flex flex-col gap-4 relative", className)}>
       <section className={styles.container()}>
@@ -45,21 +49,18 @@ const MoverProfileCard = ({ data, className }: MoverProfileCardProps) => {
           <ProfileImage imgUrl={data.imageUrl} className="hidden pc:block" />
           <div className="flex flex-col gap-3.5 pc:gap-4">
             <MoverExperience data={data} />
+
             <div className="flex flex-col gap-1 pc:gap-2 pc:flex-row">
-              <div className="flex items-center gap-1">
-                <GrayLabel>제공 서비스</GrayLabel>
-                <div className={styles.text}>
-                  {data.services
-                    .map((service) => getServiceText(service))
-                    .join(", ")}
-                </div>
-              </div>
-              <div className={styles.info}>
-                <GrayLabel>지역</GrayLabel>
-                <div className={styles.text}>
-                  {data.regions.map((code) => getRegionText(code)).join(", ")}
-                </div>
-              </div>
+              <TextWithGrayLabel
+                variant="border"
+                label="제공 서비스"
+                text={serviceText}
+              />
+              <TextWithGrayLabel
+                variant="border"
+                label="지역"
+                text={regionText}
+              />
             </div>
           </div>
         </div>

--- a/src/components/cards/PendingRequestCard.stories.tsx
+++ b/src/components/cards/PendingRequestCard.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import PendingRequestCard from "./PendingRequestCard";
 
-const meta = {
+const meta: Meta<typeof PendingRequestCard> = {
   title: "Components/Cards/PendingRequestCard",
   component: PendingRequestCard,
   parameters: {
@@ -15,7 +15,7 @@ const meta = {
     ),
   ],
   tags: ["autodocs"],
-} satisfies Meta<typeof PendingRequestCard>;
+};
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -39,7 +39,7 @@ const mockData = {
   confirmCount: 12,
   favoriteCount: 22,
   isFavorite: false,
-  introduction: "성실 정확 한 줄 평가",
+  introduction: "성실 정�� 한 줄 평가",
   services: [0, 1],
   regions: [82031, 8202],
   movingDate: "2024-11-30T10:00:00.000Z",

--- a/src/components/cards/PendingRequestCard.stories.tsx
+++ b/src/components/cards/PendingRequestCard.stories.tsx
@@ -53,6 +53,8 @@ export const Default: Story = {
   args: {
     data: mockData,
     size: "responsive",
+    onPrimaryClick: () => alert("견적 확정하기 클릭"),
+    onOutlinedClick: () => alert("상세보기 클릭"),
   },
 };
 
@@ -61,5 +63,16 @@ export const WithCustomClassName: Story = {
     data: mockData,
     size: "responsive",
     className: "max-w-[800px]",
+    onPrimaryClick: () => alert("견적 확정하기 클릭"),
+    onOutlinedClick: () => alert("상세보기 클릭"),
+  },
+};
+
+export const NonDesignated: Story = {
+  args: {
+    data: { ...mockData, isDesignated: false },
+    size: "responsive",
+    onPrimaryClick: () => alert("견적 확정하기 클릭"),
+    onOutlinedClick: () => alert("상세보기 클릭"),
   },
 };

--- a/src/components/cards/PendingRequestCard.stories.tsx
+++ b/src/components/cards/PendingRequestCard.stories.tsx
@@ -58,16 +58,6 @@ export const Default: Story = {
   },
 };
 
-export const WithCustomClassName: Story = {
-  args: {
-    data: mockData,
-    size: "responsive",
-    className: "max-w-[800px]",
-    onPrimaryClick: () => alert("견적 확정하기 클릭"),
-    onOutlinedClick: () => alert("상세보기 클릭"),
-  },
-};
-
 export const NonDesignated: Story = {
   args: {
     data: { ...mockData, isDesignated: false },

--- a/src/components/cards/PendingRequestCard.tsx
+++ b/src/components/cards/PendingRequestCard.tsx
@@ -11,9 +11,9 @@ import {
   type FavoriteFields,
   Address,
 } from "@/types/mover";
-import GrayLabel from "../common/card/GrayLabel";
 import Button from "../common/Button";
 import { formatDateWithDay } from "@/utils/utilFunctions";
+import TextWithGrayLabel from "../common/card/TextWithGrayLabel";
 
 interface PendingRequestData
   extends FullMoverData,
@@ -25,26 +25,40 @@ interface PendingRequestData
 
 type PendingRequestCardProps = CardProps & {
   data: PendingRequestData;
+  onPrimaryClick: () => void;
+  onOutlinedClick: () => void;
+};
+
+export const QuoteAmount = ({ amount }: { amount: number }) => {
+  return (
+    <span className="flex gap-2 items-center justify-end">
+      <p className="text-md font-medium pc:text-2lg">견적금액</p>
+      <p className="text-2lg font-bold pc:text-2xl">
+        {amount.toLocaleString()}원
+      </p>
+    </span>
+  );
+};
+
+const styles = {
+  chipContainer: "flex gap-2",
+  labelsContainer:
+    "flex gap-2 flex-col text-md font-medium pc:text-2lg pc:gap-4",
+  buttonContainer: "flex flex-col gap-2 tablet:flex-row",
 };
 
 const PendingRequestCard = ({
   data,
   size,
   className,
+  onPrimaryClick,
+  onOutlinedClick,
 }: PendingRequestCardProps) => {
   const serviceType = mapServiceType([data.service])[0];
 
-  const handleConfirmClick = () => {
-    console.log("견적 확정하기 api 호출");
-  };
-
-  const handleDetailClick = (quoteId: number) => {
-    console.log("상세보기 페이지로 이동");
-  };
-
   return (
     <CardContainer className="max-w-[688px]" size={size} gap="gap-3.5 pc:gap-6">
-      <div className="flex gap-2">
+      <div className={styles.chipContainer}>
         <ServiceChip variant="pendingConfirm" />
         <ServiceChip variant={serviceType as ChipType} />
         {data.isDesignated && <ServiceChip variant="designatedQuote" />}
@@ -52,37 +66,23 @@ const PendingRequestCard = ({
 
       <MoverInfo data={data} />
 
-      <div className="flex gap-2 flex-col text-md font-medium pc:text-2lg pc:gap-4">
-        <div className="flex items-center gap-1">
-          <GrayLabel>이사일</GrayLabel>
-          <span className="truncate overflow-hidden whitespace-nowrap">
-            {formatDateWithDay(data.movingDate)}
-          </span>
-        </div>
-        <div className="flex items-center gap-1">
-          <GrayLabel>출발</GrayLabel>
-          <span className="truncate overflow-hidden whitespace-nowrap">
-            {data.pickupAddress}
-          </span>
-        </div>
-        <div className="flex items-center gap-1">
-          <GrayLabel>도착</GrayLabel>
-          <span className="truncate overflow-hidden whitespace-nowrap">
-            {data.dropOffAddress}
-          </span>
-        </div>
+      <div className={styles.labelsContainer}>
+        <TextWithGrayLabel
+          label="이사일"
+          text={formatDateWithDay(data.movingDate)}
+        />
+        <TextWithGrayLabel label="출발" text={data.pickupAddress} />
+        <TextWithGrayLabel label="도착" text={data.dropOffAddress} />
       </div>
-      <div className="flex gap-2 items-center justify-end">
-        <span className="text-md font-medium pc:text-2lg">견적금액</span>
-        <span className="text-2lg font-bold pc:text-2xl">
-          {data.cost.toLocaleString()}원
-        </span>
+      <QuoteAmount amount={data.cost} />
+      <div className={styles.buttonContainer}>
+        <Button onClick={onPrimaryClick} width="100%">
+          견적 확정하기
+        </Button>
+        <Button onClick={onOutlinedClick} variant="outlined" width="100%">
+          상세보기
+        </Button>
       </div>
-
-      <Button onClick={handleConfirmClick}>견적 확정하기</Button>
-      <Button onClick={() => handleDetailClick(data.id)} variant="outlined">
-        상세보기
-      </Button>
     </CardContainer>
   );
 };

--- a/src/components/cards/SentQuoteCard.stories.tsx
+++ b/src/components/cards/SentQuoteCard.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import SentQuoteCard from "./SentQuoteCard";
+
+const meta: Meta<typeof SentQuoteCard> = {
+  title: "Components/Cards/SentQuoteCard",
+  component: SentQuoteCard,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultData = {
+  id: 100,
+  requestDate: "2024-03-17T12:00:00.000Z",
+  service: 0,
+  isDesignated: true,
+  name: "김일반",
+  movingDate: "2024-11-30T12:00:00.000Z",
+  pickupAddress: "서울특별시 강남구 역삼동 123-456",
+  dropOffAddress: "서울특별시 서초구 서초동 789-012",
+  isCompleted: false,
+  isConfirmed: false,
+  cost: 150000,
+};
+
+const logButtonClick = () => console.log("Button clicked");
+
+export const Default: Story = {
+  args: {
+    data: defaultData,
+    onButtonClick: logButtonClick,
+  },
+};
+
+export const Completed: Story = {
+  args: {
+    data: {
+      ...defaultData,
+      isCompleted: true,
+      isConfirmed: true,
+      cost: 180000,
+    },
+    onButtonClick: logButtonClick,
+  },
+};
+
+export const Confirmed: Story = {
+  args: {
+    data: {
+      ...defaultData,
+      isCompleted: false,
+      isConfirmed: true,
+      cost: 200000,
+    },
+    onButtonClick: logButtonClick,
+  },
+};
+
+export const Designated: Story = {
+  args: {
+    data: {
+      ...defaultData,
+      isDesignated: true,
+      cost: 220000,
+    },
+    onButtonClick: logButtonClick,
+  },
+};
+
+export const NotDesignated: Story = {
+  args: {
+    data: {
+      ...defaultData,
+      isDesignated: false,
+      cost: 140000,
+    },
+    onButtonClick: logButtonClick,
+  },
+};

--- a/src/components/cards/SentQuoteCard.tsx
+++ b/src/components/cards/SentQuoteCard.tsx
@@ -1,0 +1,49 @@
+import { type QuoteDetailsData } from "@/types/mover";
+import CardContainer from "../common/card/CardContainer";
+import QuoteDetails from "../common/card/QuoteDetails";
+import { QuoteAmount } from "./PendingRequestCard";
+import cn from "@/config/clsx";
+
+interface MoverQuoteData extends QuoteDetailsData {
+  isCompleted: boolean;
+  isConfirmed: boolean;
+  cost: number;
+}
+
+interface SentQuoteCardProps {
+  data: MoverQuoteData;
+  className?: string;
+  onButtonClick: () => void;
+}
+
+const styles = {
+  completedOverlay:
+    "absolute inset-0 bg-[#040404A3] rounded-[16px] flex flex-col items-center justify-center text-white z-10 border-solid border-[1px] border-grayscale-300",
+  completedText: "text-2lg font-semibold mb-4",
+  completedButton:
+    "px-[18px] py-[10px] bg-pr-blue-100 text-pr-blue-300 text-lg font-semibold rounded-[16px] border-solid border-[1px] border-pr-blue-200 hover:bg-pr-blue-200 hover:text-white",
+};
+
+const SentQuoteCard = ({
+  data,
+  className,
+  onButtonClick,
+}: SentQuoteCardProps) => {
+  return (
+    <CardContainer className={cn("relative", className)}>
+      <QuoteDetails data={data} />
+      <QuoteAmount amount={data.cost} />
+
+      {data.isCompleted && (
+        <div className={styles.completedOverlay}>
+          <p className={styles.completedText}>이사 완료된 견적이에요</p>
+          <button className={styles.completedButton} onClick={onButtonClick}>
+            견적 상세보기
+          </button>
+        </div>
+      )}
+    </CardContainer>
+  );
+};
+
+export default SentQuoteCard;

--- a/src/components/common/card/CardContainer.tsx
+++ b/src/components/common/card/CardContainer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { cva } from "class-variance-authority";
 import cn from "@/config/clsx";
 

--- a/src/components/common/card/GrayLabel.stories.tsx
+++ b/src/components/common/card/GrayLabel.stories.tsx
@@ -22,14 +22,14 @@ export const Default: Story = {
 export const Border: Story = {
   args: {
     children: "라벨 텍스트",
-    type: "border",
+    variant: "border",
   },
 };
 
 export const Solid: Story = {
   args: {
     children: "라벨 텍스트",
-    type: "solid",
+    variant: "solid",
   },
 };
 
@@ -52,18 +52,18 @@ export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
       <div className="flex gap-2">
-        <GrayLabel type="border" size="fixed">
+        <GrayLabel variant="border" size="fixed">
           Border Fixed
         </GrayLabel>
-        <GrayLabel type="border" size="responsive">
+        <GrayLabel variant="border" size="responsive">
           Border Responsive
         </GrayLabel>
       </div>
       <div className="flex gap-2">
-        <GrayLabel type="solid" size="fixed">
+        <GrayLabel variant="solid" size="fixed">
           Solid Fixed
         </GrayLabel>
-        <GrayLabel type="solid" size="responsive">
+        <GrayLabel variant="solid" size="responsive">
           Solid Responsive
         </GrayLabel>
       </div>

--- a/src/components/common/card/GrayLabel.tsx
+++ b/src/components/common/card/GrayLabel.tsx
@@ -1,10 +1,16 @@
 import { cva } from "class-variance-authority";
 
-const greyLabelVariants = cva(
+type GrayLabelProps = {
+  children: React.ReactNode;
+  variant?: "border" | "solid";
+  size?: "fixed" | "responsive";
+};
+
+const grayLabelVariants = cva(
   "flex-shrink-0 w-fit text-md font-medium text-grayscale-400 py-0.5 px-1.5 rounded-[4px]",
   {
     variants: {
-      type: {
+      variant: {
         border: "border-solid border-[1px] border-line-100 bg-bg-200",
         solid: "bg-bg-400 border-solid border-[1px] border-bg-400",
       },
@@ -14,22 +20,16 @@ const greyLabelVariants = cva(
       },
     },
     defaultVariants: {
-      type: "solid",
+      variant: "solid",
       size: "responsive",
     },
   }
 );
 
-const GreyLabel = ({
-  children,
-  type,
-  size,
-}: {
-  children: React.ReactNode;
-  type?: "border" | "solid";
-  size?: "fixed" | "responsive";
-}) => {
-  return <span className={greyLabelVariants({ type, size })}>{children}</span>;
+const GrayLabel = ({ children, variant, size }: GrayLabelProps) => {
+  return (
+    <span className={grayLabelVariants({ variant, size })}>{children}</span>
+  );
 };
 
-export default GreyLabel;
+export default GrayLabel;

--- a/src/components/common/card/NameText.stories.tsx
+++ b/src/components/common/card/NameText.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import NameText from "./NameText";
+
+const meta = {
+  title: "Common/Card/NameText",
+  component: NameText,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof NameText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MoverResponsive: Story = {
+  args: {
+    text: "홍길동",
+    type: "mover",
+    size: "responsive",
+  },
+};
+
+export const MoverFixed: Story = {
+  args: {
+    text: "홍길동",
+    type: "mover",
+    size: "fixed",
+  },
+};
+
+export const CustomerResponsive: Story = {
+  args: {
+    text: "김철수",
+    type: "customer",
+    size: "responsive",
+  },
+};
+
+export const CustomerFixed: Story = {
+  args: {
+    text: "김철수",
+    type: "customer",
+    size: "fixed",
+  },
+};

--- a/src/components/common/card/NameText.tsx
+++ b/src/components/common/card/NameText.tsx
@@ -1,0 +1,37 @@
+import cn from "@/config/clsx";
+import { cva } from "class-variance-authority";
+
+const nameVariants = cva("text-md font-semibold", {
+  variants: {
+    size: {
+      responsive: "pc:text-lg",
+      fixed: "",
+    },
+    defaultVariants: {
+      size: "responsive",
+      type: "mover",
+    },
+  },
+});
+
+const NameText = ({
+  text,
+  type,
+  size,
+  className,
+}: {
+  text: string;
+  type: "mover" | "customer";
+  size?: "responsive" | "fixed";
+  className?: string;
+}) => {
+  const nameType = type === "mover" ? "기사님" : "고객님";
+
+  return (
+    <p className={cn(nameVariants({ size }), className)}>
+      {text} <span>{nameType}</span>
+    </p>
+  );
+};
+
+export default NameText;

--- a/src/components/common/card/QuoteDetails.stories.tsx
+++ b/src/components/common/card/QuoteDetails.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import QuoteDetails from "./QuoteDetails";
+
+const meta = {
+  title: "Common/Card/QuoteDetails",
+  component: QuoteDetails,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof QuoteDetails>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockData = {
+  id: 100,
+  requestDate: "2024-03-17T12:00:00.000Z",
+  service: 0,
+  isDesignated: true,
+  name: "김일반",
+  movingDate: "2024-11-30T12:00:00.000Z",
+  pickupAddress: "서울특별시 강남구 역삼동 123-456",
+  dropOffAddress: "서울특별시 서초구 서초동 789-012",
+  isCompleted: false,
+  isRejected: false,
+};
+
+export const Default: Story = {
+  args: {
+    data: mockData,
+  },
+};

--- a/src/components/common/card/QuoteDetails.tsx
+++ b/src/components/common/card/QuoteDetails.tsx
@@ -30,6 +30,7 @@ const QuoteDetails = ({ data }: { data: QuoteDetailsData }) => {
     <>
       <div className={styles.topContainer}>
         <div className={styles.chipContainer}>
+          {data.isConfirmed && <ServiceChip variant="confirmed" />}
           <ServiceChip variant={serviceType as ChipType} />
           {data.isDesignated && <ServiceChip variant="designatedQuote" />}
         </div>

--- a/src/components/common/card/QuoteDetails.tsx
+++ b/src/components/common/card/QuoteDetails.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { mapServiceType } from "@/utils/utilFunctions";
+import { formatTimeAgo } from "@/utils/utilFunctions";
+import { formatDateWithDay } from "@/utils/utilFunctions";
+import LineSeparator from "../LineSeparator";
+import NameText from "./NameText";
+import { ChipType } from "./ServiceChip";
+import ServiceChip from "./ServiceChip";
+import TextWithGrayLabel from "./TextWithGrayLabel";
+import { type QuoteDetailsData } from "@/types/mover";
+
+const styles = {
+  topContainer: "flex items-center justify-between",
+  buttonContainer: "flex flex-col gap-2 tablet:flex-row w-full",
+  chipContainer: "flex items-center gap-2",
+  requestDate: "text-xs text-gray-500 justify-self-end pc:text-md",
+  name: "text-lg font-semibold pc:text-xl",
+  requestInfoContainer: "flex flex-col gap-2.5 tablet:gap-2 pc:gap-3.5 pc:p-4",
+  addressContainer:
+    "flex flex-col gap-2 tablet:flex-row tablet:items-center tablet:gap-3",
+};
+
+const QuoteDetails = ({ data }: { data: QuoteDetailsData }) => {
+  const serviceType = mapServiceType([data.service])[0];
+  const timeAgo = formatTimeAgo(data.requestDate);
+  const movingDate = formatDateWithDay(data.movingDate);
+
+  return (
+    <>
+      <div className={styles.topContainer}>
+        <div className={styles.chipContainer}>
+          <ServiceChip variant={serviceType as ChipType} />
+          {data.isDesignated && <ServiceChip variant="designatedQuote" />}
+        </div>
+        <time className={styles.requestDate}>{timeAgo}</time>
+      </div>
+      <div className={styles.requestInfoContainer}>
+        <NameText text={data.name} type="customer" className={styles.name} />
+        <TextWithGrayLabel
+          label="이사일"
+          text={movingDate}
+          className="tablet:hidden"
+        />
+        <LineSeparator direction="horizontal" />
+        <div className={styles.addressContainer}>
+          <TextWithGrayLabel label="출발" text={data.pickupAddress} />
+          <LineSeparator className="hidden tablet:block" />
+          <TextWithGrayLabel label="도착" text={data.dropOffAddress} />
+          <LineSeparator className="hidden tablet:block" />
+          <TextWithGrayLabel
+            label="이사일"
+            text={movingDate}
+            className="hidden tablet:flex"
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default QuoteDetails;

--- a/src/components/common/card/ServiceChip.tsx
+++ b/src/components/common/card/ServiceChip.tsx
@@ -14,6 +14,7 @@ const chipVariants = cva(
         officeMove: "bg-pr-blue-100 text-pr-blue-300 pl-[3px] pr-1.5",
         designatedQuote: "bg-pr-red-100 text-pr-red-200 pl-[3px] pr-1.5",
         pendingConfirm: "bg-[rgba(242,243,248,1)] text-pr-blue-400 px-1.5",
+        confirmed: "bg-[rgba(242,243,248,1)] text-pr-blue-400 px-1.5",
       },
       size: {
         fixed: "",
@@ -32,7 +33,9 @@ type ChipWithIconType =
   | "homeMove"
   | "officeMove"
   | "designatedQuote";
-type ChipWithoutIconType = "pendingConfirm";
+
+type ChipWithoutIconType = "pendingConfirm" | "confirmed";
+
 export type ChipType = ChipWithIconType | ChipWithoutIconType;
 
 const icons: Record<ChipWithIconType, string> = {
@@ -48,6 +51,7 @@ const labels: Record<ChipType, string> = {
   officeMove: "사무실이사",
   designatedQuote: "지정 견적 이사",
   pendingConfirm: "견적 대기",
+  confirmed: "견적 확정",
 } as const;
 
 interface ChipProps extends VariantProps<typeof chipVariants> {

--- a/src/components/common/card/TextWithGrayLabel.stories.tsx
+++ b/src/components/common/card/TextWithGrayLabel.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import TextWithGrayLabel from "./TextWithGrayLabel";
+
+const meta = {
+  title: "Common/TextWithGrayLabel",
+  component: TextWithGrayLabel,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof TextWithGrayLabel>;
+
+export default meta;
+type Story = StoryObj<typeof TextWithGrayLabel>;
+
+export const Default: Story = {
+  args: {
+    label: "라벨",
+    text: "텍스트",
+  },
+};
+
+export const WithBorderVariant: Story = {
+  args: {
+    label: "라벨",
+    text: "텍스트",
+    variant: "border",
+  },
+};
+
+export const FixedSize: Story = {
+  args: {
+    label: "라벨",
+    text: "텍스트",
+    size: "fixed",
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    label: "라벨",
+    text: "이것은 매우 긴 텍스트입니다. truncate가 적용되어 있어 길이가 넘어가면 ...으로 표시됩니다.",
+  },
+};

--- a/src/components/common/card/TextWithGrayLabel.tsx
+++ b/src/components/common/card/TextWithGrayLabel.tsx
@@ -30,16 +30,20 @@ const TextWithGrayLabel = ({
   label,
   text,
   className,
+  variant = "solid",
   size = "responsive",
 }: {
   label: string;
   text: string;
   className?: string;
+  variant?: "solid" | "border";
   size?: "responsive" | "fixed";
 }) => {
   return (
     <span className={cn(textWithGrayLabelVariants({ size }), className)}>
-      <GrayLabel size={size}>{label}</GrayLabel>
+      <GrayLabel variant={variant} size={size}>
+        {label}
+      </GrayLabel>
       <p className={cn(textVariants({ size }))}>{text}</p>
     </span>
   );

--- a/src/components/common/card/TextWithGrayLabel.tsx
+++ b/src/components/common/card/TextWithGrayLabel.tsx
@@ -1,0 +1,48 @@
+import cn from "@/config/clsx";
+import GrayLabel from "./GrayLabel";
+import { cva } from "class-variance-authority";
+
+const textWithGrayLabelVariants = cva("flex gap-2 items-center", {
+  variants: {
+    size: {
+      responsive: "pc:gap-[12px] ",
+      fixed: "",
+    },
+  },
+  defaultVariants: {
+    size: "responsive",
+  },
+});
+
+const textVariants = cva("text-md font-medium truncate", {
+  variants: {
+    size: {
+      responsive: "pc:text-2lg",
+      fixed: "",
+    },
+  },
+  defaultVariants: {
+    size: "responsive",
+  },
+});
+
+const TextWithGrayLabel = ({
+  label,
+  text,
+  className,
+  size = "responsive",
+}: {
+  label: string;
+  text: string;
+  className?: string;
+  size?: "responsive" | "fixed";
+}) => {
+  return (
+    <span className={cn(textWithGrayLabelVariants({ size }), className)}>
+      <GrayLabel size={size}>{label}</GrayLabel>
+      <p className={cn(textVariants({ size }))}>{text}</p>
+    </span>
+  );
+};
+
+export default TextWithGrayLabel;

--- a/src/types/mover.d.ts
+++ b/src/types/mover.d.ts
@@ -53,10 +53,9 @@ export interface QuoteDetailsData {
   requestDate: string;
   service: number;
   isDesignated: boolean;
+  isConfirmed?: boolean;
   name: string;
   movingDate: string;
   pickupAddress: string;
   dropOffAddress: string;
-  isCompleted: boolean;
-  isRejected: boolean;
 }

--- a/src/types/mover.d.ts
+++ b/src/types/mover.d.ts
@@ -47,3 +47,16 @@ export interface RequestDetails {
   requestDate: string;
   cost: number;
 }
+
+export interface QuoteDetailsData {
+  id: number;
+  requestDate: string;
+  service: number;
+  isDesignated: boolean;
+  name: string;
+  movingDate: string;
+  pickupAddress: string;
+  dropOffAddress: string;
+  isCompleted: boolean;
+  isRejected: boolean;
+}

--- a/src/utils/utilFunctions.ts
+++ b/src/utils/utilFunctions.ts
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import { format, formatDistanceToNow } from "date-fns";
 import { ko } from "date-fns/locale";
 import { SERVICE_CODES } from "@/variables/services";
 import { SERVICE_TEXTS } from "@/variables/service";

--- a/src/utils/utilFunctions.ts
+++ b/src/utils/utilFunctions.ts
@@ -9,6 +9,7 @@ export const formatCount = (count: number) => {
   return count.toLocaleString();
 };
 
+//ServiceChip 용
 export const mapServiceType = (services: number[]) => {
   return services.map(
     (service) => SERVICE_CODES[service as keyof typeof SERVICE_CODES]
@@ -26,4 +27,22 @@ export const getRegionText = (code: number): string => {
 
 export const getServiceText = (code: number): string => {
   return SERVICE_TEXTS[code as keyof typeof SERVICE_TEXTS] || "서비스 미정";
+};
+
+export const formatTimeAgo = (dateString: string) => {
+  try {
+    const date = new Date(dateString);
+
+    if (isNaN(date.getTime())) {
+      throw new Error("Invalid date");
+    }
+
+    return formatDistanceToNow(date, {
+      addSuffix: true,
+      locale: ko,
+    });
+  } catch (error) {
+    console.error("Date formatting error:", error);
+    return "날짜 없음";
+  }
 };

--- a/src/variables/services.ts
+++ b/src/variables/services.ts
@@ -3,3 +3,9 @@ export const SERVICE_CODES = {
   1: "homeMove",
   2: "officeMove",
 };
+
+export const SERVICE_TEXTS = {
+  0: "소형이사",
+  1: "가정이사",
+  2: "사무실이사",
+};


### PR DESCRIPTION
#### 추가사항

**참고 issue:** #5  코멘트 참고

- [x] IncomingRequestCard
- [x] SentQuoteCard

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [x] to-do에서 진행상황 볼수 있습니다


#### 테스트 완료 여부

(에러 유무 테스트)

- [x] npm run dev
- [x] npm run storybook

#### 스크린샷

![image](이미지url)

#### 추가 코멘트

버튼 있는 카드들은 각 버튼 action을 prop으로 받게 했습니다
예시)
onPrimaryClick ( primary button 디자인 click시 실행될 함수 받는 prop)
onOutlinedClick ( outlined button 디자인 click시 실행될 함수 받는 prop)
onButtonClick( 그 외 디자인)

스토리북 참조.

![Screenshot 2024-12-04 at 3 34 35 PM](https://github.com/user-attachments/assets/220b5f4c-369e-43cc-8518-ab236c9d8559)

![Screenshot 2024-12-04 at 5 41 55 PM](https://github.com/user-attachments/assets/4ce508f7-763d-425c-986b-0a5c64664149)
