### PR TITLE
[이진우] 드롭다운 견적서용 추가

### DIFF
--- a/src/components/dropdowns/DropdownQuote.stories.tsx
+++ b/src/components/dropdowns/DropdownQuote.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import DropdownQuote from "./DropdownQuote";
+
+const meta: Meta<typeof DropdownQuote> = {
+  title: "Components/dropdows/DropdownQuote",
+  component: DropdownQuote,
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark-gray",
+      values: [
+        { name: "dark-gray", value: "#333333" },
+        { name: "white", value: "#ffffff" },
+      ],
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof DropdownQuote>;
+
+export default meta;
+type Story = StoryObj<typeof DropdownQuote>;
+
+function printDropdownQuoteCode(quoteFilterCode: number): void {
+  console.log("선택 코드(all : 0 , confirmed : 1) :", quoteFilterCode);
+}
+
+export const base: Story = {
+  args: {
+    onSelect: printDropdownQuoteCode,
+  },
+};

--- a/src/components/dropdowns/DropdownQuote.tsx
+++ b/src/components/dropdowns/DropdownQuote.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import cn from "@/config/cn";
+
+import {
+  Dropdown,
+  DropdownList,
+  DropdownItem,
+  DropdownImage,
+  DropdownFilter,
+} from "../common/Dropdown";
+
+type DropdownQuoteProps = {
+  onSelect: (regionCode: number) => void;
+  disabled: boolean;
+};
+
+const DROPDOWN_QUOTE_LIST: string[] = ["전체", "확정한 견적서"];
+const ALL_QUOTE: number = 0;
+const CONFIRMED_QUOTE: number = 1;
+
+export default function DropdownQuote({
+  onSelect,
+  disabled,
+}: DropdownQuoteProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentFilter, setCurrentFilter] = useState<string>(
+    DROPDOWN_QUOTE_LIST[ALL_QUOTE]
+  );
+
+  const dropdownStyles = {
+    base: "relative box-border flex flex-row justify-between items-center \
+    pl-3.5 pr-2.5 w-[127px] h-[36px] \
+    border-solid border-[1px] border-grayscale-100 rounded-lg \
+    bg-transparent shadow-[4px_4px_10px_rgba(238,238,238,0.1)] \
+    text-black-400 \
+    cursor-pointer \
+    pc:rounded-2xl pc:px-[24px] pc:w-[190px] pc:h-[64px] pc:text-2lg",
+    able: "shadow-md hover:bg-pr-blue-50",
+    open: "border-pr-blue-300 text-pr-blue-300",
+    disabled: "cursor-not-allowed",
+  };
+
+  const dropdownTriggerClass = cn(dropdownStyles.base, {
+    [dropdownStyles.able]: !disabled,
+    [dropdownStyles.open]: isOpen,
+    [dropdownStyles.disabled]: disabled,
+  });
+
+  const dropdownListClass = cn(
+    "absolute flex flex-col items-center overflow-hidden\
+    top-10 right-0 w-[127px] \
+    border-solid border-[1px] border-line-100 rounded-lg \
+    bg-white \
+    pc:top-[72px] pc:w-[190px]"
+  );
+
+  const dropdownItemClass = cn(
+    "flex flex-col justify-center \
+    px-3.5 w-full h-[36px] \
+    text-md text-black-400 font-medium \
+    hover:bg-pr-blue-50 \
+    cursor-pointer \
+    pc:px-[24px] pc:h-[64px] pc:text-2lg"
+  );
+
+  const handleSortChange = (code: number) => {
+    setCurrentFilter(DROPDOWN_QUOTE_LIST[code]);
+    onSelect(code);
+    setIsOpen(false);
+  };
+
+  const items = DROPDOWN_QUOTE_LIST.map((items, index) => {
+    return {
+      label: items,
+      onClick: () => handleSortChange(index),
+    };
+  });
+
+  return (
+    <Dropdown
+      trigger={
+        <div className={dropdownTriggerClass}>
+          <DropdownFilter>{currentFilter}</DropdownFilter>
+          <DropdownImage isOpen={isOpen} />
+        </div>
+      }
+      isOpen={isOpen}
+      onToggle={() => setIsOpen((prev) => !prev)}
+    >
+      <DropdownList
+        className={dropdownListClass}
+        items={items.map((item, index) => (
+          <DropdownItem
+            key={index}
+            className={dropdownItemClass}
+            onClick={item.onClick}
+          >
+            {item.label}
+          </DropdownItem>
+        ))}
+      />
+    </Dropdown>
+  );
+}


### PR DESCRIPTION
#### 추가사항

내 견적 관리(일반용) - 받았던 견적 페이지에서 사용되는 드롭다운

**참고 issue:**

- [x] https://github.com/codeit-moving/moving-fe/issues/50


#### 진행예정 (완료했다면 따로없거나 or 기능확장)


#### 테스트 완료 여부

(에러 유무 테스트)

- [x] npm run storybook

#### 스크린샷

작성한 드롭다운
![image](https://github.com/user-attachments/assets/e3851e87-5728-4059-810e-66989d6ed7d3)
![image](https://github.com/user-attachments/assets/921527b6-f0ff-448d-923a-c3f599859fe3)

피그마 디자인
![image](https://github.com/user-attachments/assets/b24bfac0-f499-4b0b-a034-d02b68e9b4ed)
![image](https://github.com/user-attachments/assets/9dff634d-9bd4-4122-9631-d480ec730004)


#### 추가 코멘트

list의 width와 Dropdown과의 거리가 피그마에 나온 디자인을 그대로 적용시켰을 때 기존의 다른 UI와 통일성이 떨어져, 기존 드롭다운의 UI와 같이 list의 width(Dropdown 동일)/ 거리를 수정하였습니다.