### PR TITLE
[임송이] 카드 컴포넌트 CSS 수정

### DIFF
--- a/src/components/cards/FavoriteMoverCard.tsx
+++ b/src/components/cards/FavoriteMoverCard.tsx
@@ -25,7 +25,7 @@ const FavoriteMoverCard = ({ data, className }: FavoriteMoverCardProps) => {
           <ServiceChip variant={serviceType as ChipType} key={serviceType} />
         ))}
       </div>
-      <MoverInfo data={data} />
+      <MoverInfo data={data} isLarge={true} />
     </CardContainer>
   );
 };

--- a/src/components/cards/MoverProfileCard.tsx
+++ b/src/components/cards/MoverProfileCard.tsx
@@ -64,7 +64,11 @@ const MoverProfileCard = ({
         </div>
 
         <div className={cn(styles.innerContainer(), "pc:relative")}>
-          <ProfileImage imgUrl={data.imageUrl} className="hidden pc:block" />
+          <ProfileImage
+            imgUrl={data.imageUrl}
+            className="hidden pc:block"
+            isLarge={true}
+          />
           <div className="flex flex-col gap-3.5 pc:gap-4">
             <MoverExperience data={data} />
 

--- a/src/components/cards/MyReviewCard.tsx
+++ b/src/components/cards/MyReviewCard.tsx
@@ -42,7 +42,7 @@ const MyReviewCard = ({ data, className }: MyReviewCardProps) => {
       </div>
 
       <div className="flex items-center gap-2.5 pc:gap-6 pc:py-2">
-        <ProfileImage imgUrl={data.imageUrl} />
+        <ProfileImage imgUrl={data.imageUrl} isLarge={true} />
         <div className="flex flex-col gap-1 pc:gap-2">
           <NameText text={data.nickname} type="mover" />
           <div className="flex items-center gap-[12.5px]">

--- a/src/components/common/card/FavoriteUi.tsx
+++ b/src/components/common/card/FavoriteUi.tsx
@@ -2,20 +2,51 @@ import Image from "next/image";
 import assets from "@/variables/images";
 import { formatCount } from "@/utils/utilFunctions";
 import { FavoriteFields } from "@/types/mover";
+import { VariantProps, cva } from "class-variance-authority";
+
+const favoriteVariants = cva("flex items-center gap-0.5", {
+  variants: {
+    size: {
+      fixed: "",
+      responsive: "pc:gap-1",
+    },
+  },
+  defaultVariants: {
+    size: "responsive",
+  },
+});
+
+const textVariants = cva("text-sm font-medium text-pr-blue-400", {
+  variants: {
+    size: {
+      fixed: "",
+      responsive: "pc:text-2lg",
+    },
+  },
+  defaultVariants: {
+    size: "responsive",
+  },
+});
+
+interface FavoriteUiProps
+  extends FavoriteFields,
+    VariantProps<typeof favoriteVariants> {
+  size?: "fixed" | "responsive";
+}
 
 export default function FavoriteUi({
   favoriteCount = 0,
   isFavorite = false,
-}: FavoriteFields) {
+  size,
+}: FavoriteUiProps) {
   const heartIcon = isFavorite
     ? assets.icons.likeActive
     : assets.icons.likeInactive;
 
   return (
-    <div className="inline-flex items-center gap-0.5 pc:gap-1">
+    <div className={favoriteVariants({ size })}>
       <Image src={heartIcon} alt="favorite icon" width={24} height={24} />
-
-      <span className="text-sm font-medium pc:text-2lg text-pr-blue-400">
+      <span className={textVariants({ size })}>
         {formatCount(favoriteCount)}
       </span>
     </div>

--- a/src/components/common/card/MoverInfo.tsx
+++ b/src/components/common/card/MoverInfo.tsx
@@ -7,12 +7,12 @@ import { FavoriteFields, type BaseMoverData } from "@/types/mover";
 import NameText from "./NameText";
 
 const moverInfoVariants = cva(
-  "flex gap-3 items-center text-black-300 border-solid rounded-md border-line-100 shadow-border border-[1px] p-2.5",
+  "flex gap-2.5 items-center text-black-300 border-solid rounded-md border-line-100 shadow-border border-[1px] p-2.5",
   {
     variants: {
       size: {
         fixed: "",
-        responsive: "pc:p-3",
+        responsive: "pc:p-4",
       },
     },
     defaultVariants: {
@@ -25,26 +25,28 @@ type MoverInfoProps = {
   data: BaseMoverData & FavoriteFields;
   className?: string;
   size?: "fixed" | "responsive";
+  isLarge?: boolean;
 };
 
-const MoverInfo = ({ data, className, size }: MoverInfoProps) => {
+const MoverInfo = ({ data, className, size, isLarge }: MoverInfoProps) => {
   if (!data) return null;
 
   const isResponsive = size === "responsive";
 
   return (
     <div className={cn(moverInfoVariants({ size }), className)}>
-      <ProfileImage imgUrl={data.imageUrl} size={size} />
+      <ProfileImage imgUrl={data.imageUrl} size={size} isLarge={isLarge} />
       <div
-        className={cn("flex flex-col gap-2 w-full", {
-          "pc:gap-3": isResponsive,
+        className={cn("flex flex-col gap-2.5 w-full", {
+          "pc:gap-2": isResponsive,
         })}
       >
         <div className="flex items-center justify-between">
-          <NameText text={data.nickname} type="mover" />
+          <NameText text={data.nickname} type="mover" size={size} />
           <FavoriteUi
             isFavorite={data.isFavorite}
             favoriteCount={data.favoriteCount}
+            size={size}
           />
         </div>
 

--- a/src/components/common/card/NameText.tsx
+++ b/src/components/common/card/NameText.tsx
@@ -1,28 +1,33 @@
 import cn from "@/config/cn";
 import { cva } from "class-variance-authority";
 
-const nameVariants = cva("text-md font-semibold", {
+const nameVariants = cva("font-semibold", {
   variants: {
     size: {
-      responsive: "",
-      fixed: "",
+      responsive: "text-lg",
+      fixed: "text-lg",
     },
     type: {
-      mover: "pc:text-2lg",
-      customer: "pc:text-xl",
+      mover: "",
+      customer: "",
     },
   },
+  compoundVariants: [
+    {
+      size: "responsive",
+      type: "mover",
+      className: "pc:text-2lg",
+    },
+    {
+      size: "responsive",
+      type: "customer",
+      className: "pc:text-xl",
+    },
+  ],
   defaultVariants: {
     size: "responsive",
     type: "mover",
   },
-  compoundVariants: [
-    {
-      size: "fixed",
-      type: ["mover", "customer"],
-      class: "",
-    },
-  ],
 });
 
 const NameText = ({
@@ -39,7 +44,7 @@ const NameText = ({
   const nameType = type === "mover" ? "기사님" : "고객님";
 
   return (
-    <p className={cn(nameVariants({ size }), className)}>
+    <p className={cn(nameVariants({ size, type }), className)}>
       {text} <span>{nameType}</span>
     </p>
   );

--- a/src/components/common/card/ProfileImage.stories.tsx
+++ b/src/components/common/card/ProfileImage.stories.tsx
@@ -6,6 +6,12 @@ const meta = {
   component: ProfileImage,
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component:
+          "프로필 이미지 컴포넌트 - 기본 46px, 반응형 54px, Large 80px",
+      },
+    },
   },
   tags: ["autodocs"],
 } satisfies Meta<typeof ProfileImage>;
@@ -13,21 +19,43 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof ProfileImage>;
 
+const mockImageUrl = "https://picsum.photos/200";
+
 export const Default: Story = {
   args: {
-    imgUrl: "https://picsum.photos/200",
+    imgUrl: mockImageUrl,
+    size: "responsive",
+    isLarge: false,
+  },
+};
+
+export const Fixed: Story = {
+  args: {
+    imgUrl: mockImageUrl,
+    size: "fixed",
+    isLarge: false,
+  },
+};
+
+export const Large: Story = {
+  args: {
+    imgUrl: mockImageUrl,
+    size: "responsive",
+    isLarge: true,
   },
 };
 
 export const WithoutImage: Story = {
   args: {
     imgUrl: null,
+    size: "responsive",
+    isLarge: false,
   },
 };
 
-export const CustomSize: Story = {
+export const CustomClassName: Story = {
   args: {
-    imgUrl: "https://picsum.photos/200",
+    imgUrl: mockImageUrl,
     className: "w-20 h-20",
   },
 };

--- a/src/components/common/card/ProfileImage.tsx
+++ b/src/components/common/card/ProfileImage.tsx
@@ -4,32 +4,46 @@ import assets from "@/variables/images";
 import Image from "next/image";
 
 const profileImageVariants = cva(
-  "relative bg-transparent z-1 border-2 border-solid border-pr-blue-400 rounded-full overflow-hidden shadow-card min-w-[46px] aspect-square",
+  "relative bg-transparent border-[2px] border-solid border-pr-blue-400 rounded-full overflow-hidden w-[46px] aspect-[1/1]",
   {
     variants: {
       size: {
-        fixed: "",
-        responsive: "pc:w-[80px]",
+        fixed: " ",
+        responsive: " pc:w-[54px]",
+      },
+      isLarge: {
+        true: "pc:w-[80px]",
+        false: "",
       },
     },
     defaultVariants: {
       size: "responsive",
+      isLarge: false,
     },
   }
 );
+
+interface ProfileImageProps extends VariantProps<typeof profileImageVariants> {
+  imgUrl: string | null;
+  className?: string;
+  size?: "fixed" | "responsive";
+  isLarge?: boolean;
+}
 
 const ProfileImage = ({
   imgUrl,
   className,
   size,
-}: {
-  imgUrl: string | null;
-  className?: string;
-  size?: "fixed" | "responsive";
-}) => {
+  isLarge = false,
+}: ProfileImageProps) => {
   return (
-    <div className={cn(profileImageVariants({ size }), className)}>
-      <Image src={imgUrl || assets.images.avatarRed} alt="profile image" fill />
+    <div className={cn(profileImageVariants({ size, isLarge }), className)}>
+      <Image
+        src={imgUrl || assets.images.avatarRed}
+        alt="profile image"
+        fill
+        className="object-cover"
+      />
     </div>
   );
 };

--- a/src/components/common/card/ReviewMover.tsx
+++ b/src/components/common/card/ReviewMover.tsx
@@ -35,7 +35,7 @@ const ReviewMover = ({
       </div>
 
       <div className="flex items-center gap-2.5 pc:gap-6 pc:py-2">
-        <ProfileImage imgUrl={data.imageUrl} />
+        <ProfileImage imgUrl={data.imageUrl} isLarge={true} />
         <div className="flex flex-col gap-1 pc:gap-2">
           <NameText text={data.nickname} type="mover" />
           <div className="flex gap-2 items-center pc:gap-[12.5px]">


### PR DESCRIPTION
#### 추가사항

**참고 issue:**

- [x] 카드 size="fixed"일때 responsive로 먹히는 오류 수정 (기사님찾기)
- [x] 카드에 ProfileImage pc일때 80px x 80px 디자인 인것 수정
- [x] 그 외 자잘한 css

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [x]
- []
- []

#### 테스트 완료 여부

(에러 유무 테스트)

- [x] 테스트 완료
- [x] npm run dev
- [x] npm run storybook

#### 스크린샷


![Screenshot 2024-12-13 at 9 13 36 PM](https://github.com/user-attachments/assets/193cd5ce-4d03-4f11-98d9-6bced145ddf5)


#### 추가 코멘트
이상한 문제
![Screenshot 2024-12-13 at 9 06 32 PM](https://github.com/user-attachments/assets/60ef26f6-dd9d-43e2-b219-bfdbc77e93de)

mobile 일때 46px, pc일때 56px (그러나 isLarge={true}일때 80px) 로 지정했으나
그 사이즈로 나오지 않음. 사진처럼 공간이 더 있음에도 채워지지않는 문제...


