### PR TITLE
[이진우] 로그인 후 로그인 정보 GNB에 적용

### DIFF
--- a/src/components/auth/LoginComponent.tsx
+++ b/src/components/auth/LoginComponent.tsx
@@ -12,6 +12,7 @@ import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 import { login } from "@/api/auth";
 import { useUserStore } from "@/store/userStore";
+import { getUserInfo } from "@/api/user";
 
 interface SignUpComponentProps {
   isUser: boolean;
@@ -48,8 +49,22 @@ export default function SignUpComponent({ isUser }: SignUpComponentProps) {
     }
     try {
       // 미완성. signin API response 구조 확인 필요
-      const { userDate } = await login(data);
-      useUserStore().setUserData(userDate);
+      await login(data);
+
+      const userInfo = await getUserInfo();
+      console.log("SignUpComponent userInfo: ", userInfo);
+      const userRole = userInfo.user.mover
+        ? "MOVER"
+        : userInfo.user.customer
+        ? "USER"
+        : null;
+
+      useUserStore.getState().setUserData({
+        email: userInfo.user.email,
+        name: userInfo.user.name,
+        phoneNumber: userInfo.user.phoneNumber,
+        role: userRole,
+      });
       reset();
       isUser ? router.push("/find-mover") : router.push("/mover/request");
     } catch (error: any) {

--- a/src/components/auth/LoginComponent.tsx
+++ b/src/components/auth/LoginComponent.tsx
@@ -66,7 +66,7 @@ export default function SignUpComponent({ isUser }: SignUpComponentProps) {
         role: userRole,
       });
       reset();
-      isUser ? router.push("/find-mover") : router.push("/mover/request");
+      isUser ? router.push("/find-mover") : router.push("/"); //router.push("/mover/request");
     } catch (error: any) {
       const errorMessage =
         error.response?.data?.data?.message ||

--- a/src/components/auth/RoleGuard.tsx
+++ b/src/components/auth/RoleGuard.tsx
@@ -63,7 +63,7 @@ export default function RoleGuard({
           phoneNumber: userInfo.user.phoneNumber,
           role: userRole,
         });
-        console.log("userType : ", useUserStore.getState().userRole);
+        console.log("RoleGuard userType : ", useUserStore.getState().userRole);
         const hasPermission = userRole && allowedRoles?.includes(userRole);
         if (!hasPermission) {
           router.replace(fallbackPath);

--- a/src/components/auth/RoleGuard.tsx
+++ b/src/components/auth/RoleGuard.tsx
@@ -53,7 +53,7 @@ export default function RoleGuard({
         const userInfo = await getUserInfo();
         const userRole = userInfo.user.mover
           ? "MOVER"
-          : userInfo.user.user
+          : userInfo.user.customer
           ? "USER"
           : null;
 

--- a/src/components/dropdowns/DropdownProfile.tsx
+++ b/src/components/dropdowns/DropdownProfile.tsx
@@ -39,6 +39,8 @@ export default function DropdownProfile({
     disabled: "cursor-not-allowed",
   };
 
+  console.log("DropdownProfile isMover", isMover);
+
   const dropdownTriggerClass = clsx(dropdownStyles.base, {
     [dropdownStyles.able]: !disabled,
     [dropdownStyles.open]: isOpen,

--- a/src/components/layout/GNB.tsx
+++ b/src/components/layout/GNB.tsx
@@ -51,11 +51,13 @@ const GNB = () => {
     }
   });
 
-  const { userName } = useUserStore();
-  const userType = useUserStore.getState().userRole;
+  console.log("GNB");
+  const { userName, userRole } = useUserStore();
+  console.log("userName : ", userName, "userRole : ", userRole);
+  // const userType = useUserStore.getState().userRole;
 
   const renderTabs = () => {
-    switch (userType) {
+    switch (userRole) {
       case "MOVER":
         return (
           <>
@@ -100,7 +102,7 @@ const GNB = () => {
         </div>
 
         <div className="flex flex-row items-center gap-6">
-          {userType ? (
+          {userRole ? (
             <>
               <DropdownNotification
                 onSelect={(id: number) => {
@@ -145,7 +147,7 @@ const GNB = () => {
           >
             <Image src={assets.icons.x} alt="close" width={24} height={24} />
           </button>
-          {userType ? (
+          {userRole ? (
             <div className="flex items-center gap-2 mt-8 mb-6">
               <Image
                 src={assets.icons.userProfile}

--- a/src/components/layout/GNB.tsx
+++ b/src/components/layout/GNB.tsx
@@ -52,7 +52,7 @@ const GNB = () => {
   });
 
   const { userName, userRole } = useUserStore();
-  console.log("userName : ", userName, "userRole : ", userRole);
+  console.log("GNB userName : ", userName, "userRole : ", userRole);
 
   const renderTabs = () => {
     switch (userRole) {

--- a/src/components/layout/GNB.tsx
+++ b/src/components/layout/GNB.tsx
@@ -51,10 +51,8 @@ const GNB = () => {
     }
   });
 
-  console.log("GNB");
   const { userName, userRole } = useUserStore();
   console.log("userName : ", userName, "userRole : ", userRole);
-  // const userType = useUserStore.getState().userRole;
 
   const renderTabs = () => {
     switch (userRole) {
@@ -109,7 +107,7 @@ const GNB = () => {
                   console.log(id); // 임시. 테스트용
                 }}
               />
-              <DropdownProfile name={userName} />
+              <DropdownProfile name={userName} isMover={userRole === "MOVER"} />
             </>
           ) : (
             <Link


### PR DESCRIPTION
#### 추가사항

**참고 issue:**

- [x] 일반/기사 정보를 반영한 GNB 출력

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [x] 임시로 기사 로그인 후 홈으로 이동(request 페이지로 이동시 ssr 환경의 API 호출로 에러 발생 : 이진우 개인 BE로 연동) 원복
- [ ] 확인용 주석 삭제

#### 테스트 완료 여부

(에러 유무 테스트)

- [x] npm run dev

#### 스크린샷

![image](https://github.com/user-attachments/assets/3be5a4e3-f72d-430e-aaad-088b8bf611ac)
![image](https://github.com/user-attachments/assets/00462c15-edb4-46d1-809f-b6f8d8bd25f2)


#### 추가 코멘트

진행 예정 항목은 혹시나 모를 오류 상황을 위해 확인 용 주석이 있습니다.
SSR API가 이진우-개인 BE와 연동되어 있어 임시로 로그인 후 이동되는 페이지를 수정한거라, 추후 실배포 경로가 정해지거나 BE의 수정에 맞춰 원복할 예정입니다.

나중에라도 확인을 위해 진행예정으로 남겨둔거라, 코드에 이상이 없다면 merge 진행해주시면 됩니다.
