### PR TITLE
[이진우] SSR에서 사용하는 API의 쿠키 공유 옵션 추가

### DIFF
--- a/src/api/mover.ts
+++ b/src/api/mover.ts
@@ -1,3 +1,5 @@
+import { AxiosRequestConfig } from "axios";
+
 import { type MoverDetails } from "@/components/cards/MoverInfoCard";
 import { axiosInstance } from "./axios";
 import { BaseMoverData } from "@/types/mover";
@@ -7,6 +9,7 @@ import { RatingData } from "@/types/mover";
 const PATH = "/movers";
 
 interface GetMoverListParams {
+  cookie?: string;
   nextCursorId?: string | number | null;
   order?: string;
   limit?: number;
@@ -41,6 +44,7 @@ export interface GetMoverListResponseData {
 }
 
 export const getMoverList = async ({
+  cookie,
   nextCursorId,
   order,
   limit,
@@ -49,18 +53,26 @@ export const getMoverList = async ({
   service,
   isFavorite = false,
 }: GetMoverListParams): Promise<GetMoverListResponseData> => {
+  console.log("getMoverList");
+  const headers: AxiosRequestConfig["headers"] = cookie
+    ? { Cookie: cookie }
+    : undefined;
+
   const params = {
     ...(nextCursorId && { nextCursorId: nextCursorId }),
     ...(order && { order: order }),
     ...(limit && { limit: limit }),
-    ...(keyword && { keyword: keyword }),
+    ...(keyword?.trim() && { keyword }),
     ...(region && { region: region }),
     ...(service && { service: service }),
     ...(isFavorite && { isFavorite: isFavorite }),
   };
 
   try {
-    const response = await axiosInstance.get(PATH, { params });
+    const response = await axiosInstance.get(PATH, {
+      params,
+      ...(headers && { headers }),
+    });
     return response.data;
   } catch (err) {
     console.error(err);

--- a/src/api/movingRequest.ts
+++ b/src/api/movingRequest.ts
@@ -1,3 +1,5 @@
+import { AxiosRequestConfig } from "axios";
+
 import { axiosInstance } from "./axios";
 
 import {
@@ -111,6 +113,7 @@ export type { PendingQuotesResponse, Quote, Mover, MovingRequest, Rating };
 const PATH = "/moving-requests";
 
 export async function getMovingRequestListByMover({
+  cookie,
   smallMove,
   houseMove,
   officeMove,
@@ -120,36 +123,56 @@ export async function getMovingRequestListByMover({
   limit,
   cursor,
 }: GetMovingRequestListByMoverParamData): Promise<GetMovingRequestListByMoverResponseData> {
-  const serviceQuery = `smallMove=${smallMove}&houseMove=${houseMove}&officeMove=${officeMove}`;
-  const sortQuery = `&orderBy=${orderBy}`;
-  let designateQuery = ``;
+  const headers: AxiosRequestConfig["headers"] = cookie
+    ? { Cookie: cookie }
+    : undefined;
 
-  if (isDesignated !== null) {
-    designateQuery = `&isDesignated=${isDesignated}`;
-  }
+  // const serviceQuery = `smallMove=${smallMove}&houseMove=${houseMove}&officeMove=${officeMove}`;
+  // const sortQuery = `&orderBy=${orderBy}`;
+  // let designateQuery = ``;
 
-  let keywordQuery = ``;
+  // if (isDesignated !== null) {
+  //   designateQuery = `&isDesignated=${isDesignated}`;
+  // }
 
-  if (keyword !== null && keyword?.trim().length !== 0) {
-    keywordQuery = `&keyword=${keyword}`;
-  }
+  // let keywordQuery = ``;
 
-  let limitQuery = ``;
+  // if (keyword !== null && keyword?.trim().length !== 0) {
+  //   keywordQuery = `&keyword=${keyword}`;
+  // }
 
-  if (limit) {
-    limitQuery = `&limit=${limit}`;
-  }
+  // let limitQuery = ``;
 
-  let cursorQuery = ``;
+  // if (limit) {
+  //   limitQuery = `&limit=${limit}`;
+  // }
 
-  if (cursor !== "" && cursor) {
-    cursorQuery = `&cursor=${cursor}`;
-  }
+  // let cursorQuery = ``;
 
-  const query = `${serviceQuery}${sortQuery}${designateQuery}${keywordQuery}${limitQuery}${cursorQuery}&isQuoted=false&isPastRequest=false`;
+  // if (cursor !== "" && cursor) {
+  //   cursorQuery = `&cursor=${cursor}`;
+  // }
+
+  // const query = `${serviceQuery}${sortQuery}${designateQuery}${keywordQuery}${limitQuery}${cursorQuery}&isQuoted=false&isPastRequest=false`;
+
+  const params: Record<string, any> = {
+    smallMove,
+    houseMove,
+    officeMove,
+    orderBy,
+    ...(isDesignated !== null && { isDesignated }),
+    ...(keyword?.trim() && { keyword }),
+    ...(limit && { limit }),
+    ...(cursor && { cursor }),
+    isQuoted: false,
+    isPastRequest: false,
+  };
 
   try {
-    const response = await axiosInstance.get(`${PATH}/by-mover?${query}`);
+    const response = await axiosInstance.get(`${PATH}/by-mover`, {
+      params,
+      ...(headers && { headers }),
+    });
 
     if (response.status !== 200) {
       console.error("Fetch API 호출 오류:", response.statusText);
@@ -157,7 +180,7 @@ export async function getMovingRequestListByMover({
     }
 
     // const data = await response.json();
-    console.log("query : ", query);
+    console.log("params : ", params);
     console.log("response.data : ", response.data);
 
     return response.data;

--- a/src/api/movingRequest.ts
+++ b/src/api/movingRequest.ts
@@ -127,34 +127,6 @@ export async function getMovingRequestListByMover({
     ? { Cookie: cookie }
     : undefined;
 
-  // const serviceQuery = `smallMove=${smallMove}&houseMove=${houseMove}&officeMove=${officeMove}`;
-  // const sortQuery = `&orderBy=${orderBy}`;
-  // let designateQuery = ``;
-
-  // if (isDesignated !== null) {
-  //   designateQuery = `&isDesignated=${isDesignated}`;
-  // }
-
-  // let keywordQuery = ``;
-
-  // if (keyword !== null && keyword?.trim().length !== 0) {
-  //   keywordQuery = `&keyword=${keyword}`;
-  // }
-
-  // let limitQuery = ``;
-
-  // if (limit) {
-  //   limitQuery = `&limit=${limit}`;
-  // }
-
-  // let cursorQuery = ``;
-
-  // if (cursor !== "" && cursor) {
-  //   cursorQuery = `&cursor=${cursor}`;
-  // }
-
-  // const query = `${serviceQuery}${sortQuery}${designateQuery}${keywordQuery}${limitQuery}${cursorQuery}&isQuoted=false&isPastRequest=false`;
-
   const params: Record<string, any> = {
     smallMove,
     houseMove,
@@ -175,17 +147,16 @@ export async function getMovingRequestListByMover({
     });
 
     if (response.status !== 200) {
-      console.error("Fetch API 호출 오류:", response.statusText);
+      console.error(
+        "getMovingRequestListByMover API 호출 오류:",
+        response.statusText
+      );
       throw new Error("API 요청 실패");
     }
 
-    // const data = await response.json();
-    console.log("params : ", params);
-    console.log("response.data : ", response.data);
-
     return response.data;
   } catch (err: any) {
-    console.error("Fetch API 호출 오류:", err.message);
+    console.error("getMovingRequestListByMover API 호출 오류:", err.message);
     return {
       list: [],
       serviceCounts: { smallMove: 0, houseMove: 0, officeMove: 0 },

--- a/src/app/(mover)/mover/request/RequestForm.tsx
+++ b/src/app/(mover)/mover/request/RequestForm.tsx
@@ -43,7 +43,7 @@ interface RequestQuoteData extends QuoteDetailsData {
 }
 
 interface RequestFormProps {
-  initialData?: GetMovingRequestListByMoverResponseData;
+  initialData: GetMovingRequestListByMoverResponseData;
 }
 
 export default function RequestForm({ initialData }: RequestFormProps) {
@@ -103,6 +103,11 @@ export default function RequestForm({ initialData }: RequestFormProps) {
         return isNaN(cursor) ? null : cursor;
       },
       initialPageParam: null,
+      initialData: {
+        pages: [initialData],
+        pageParams: [null],
+      },
+      staleTime: 0,
     });
 
   const styles = {

--- a/src/app/(mover)/mover/request/page.tsx
+++ b/src/app/(mover)/mover/request/page.tsx
@@ -1,29 +1,31 @@
-import RequestForm from "./RequestForm";
+import { cookies } from "next/headers";
 
+import RequestForm from "./RequestForm";
 import { getMovingRequestListByMover } from "@/api/movingRequest";
+
 import { MOVING_REQUEST_DEFAULT_PAGE_SIZE } from "@/variables/movingRequest";
 
 export default async function RequestListPage({}) {
   try {
-    // const initialData = await getMovingRequestListByMover({
-    //   keyword: "",
-    //   smallMove: true,
-    //   houseMove: true,
-    //   officeMove: true,
-    //   isDesignated: null,
-    //   orderBy: "recent",
-    //   limit: MOVING_REQUEST_DEFAULT_PAGE_SIZE,
-    //   cursor: null,
-    // });
+    const cookieStore = await cookies();
+    const cookie = `accessToken=${cookieStore.get("accessToken")?.value}`;
 
-    // console.log("Initial Data:", initialData);
+    const initialData = await getMovingRequestListByMover({
+      cookie: cookie,
+      keyword: "",
+      smallMove: true,
+      houseMove: true,
+      officeMove: true,
+      isDesignated: null,
+      orderBy: "recent",
+      limit: MOVING_REQUEST_DEFAULT_PAGE_SIZE,
+      cursor: null,
+    });
 
-    // return initialData ? (
-    //   <RequestForm initialData={initialData} />
-    // ) : (
-    //   <div>No Data</div>
-    // );
-    return <RequestForm />;
+    console.log("Initial Data:", initialData);
+    console.log("cookie:", cookie);
+
+    return <RequestForm initialData={initialData} />;
   } catch (error) {
     console.error("RequestListPage Error:", error);
     return <div>Error Loading Data</div>;

--- a/src/app/(mover)/mover/request/page.tsx
+++ b/src/app/(mover)/mover/request/page.tsx
@@ -22,9 +22,6 @@ export default async function RequestListPage({}) {
       cursor: null,
     });
 
-    console.log("Initial Data:", initialData);
-    console.log("cookie:", cookie);
-
     return <RequestForm initialData={initialData} />;
   } catch (error) {
     console.error("RequestListPage Error:", error);

--- a/src/app/(user)/find-mover/moverList.tsx
+++ b/src/app/(user)/find-mover/moverList.tsx
@@ -189,6 +189,7 @@ export default function MoverListWithFilters({
         pages: [initialData],
         pageParams: [null],
       },
+      staleTime: 0,
     });
 
   const styles = {
@@ -257,6 +258,8 @@ export default function MoverListWithFilters({
       newService = null;
     }
 
+    console.log("newService :", newService);
+
     setFormState((prev) => ({
       ...prev,
       currentServiceFilter: newService,
@@ -282,6 +285,10 @@ export default function MoverListWithFilters({
       currentSort: sorts[newSort],
     }));
   };
+
+  useEffect(() => {
+    console.log("FormState updated:", formState);
+  }, [formState]);
 
   useEffect(() => {
     const handler = setTimeout(() => {

--- a/src/app/(user)/find-mover/moverList.tsx
+++ b/src/app/(user)/find-mover/moverList.tsx
@@ -230,10 +230,6 @@ export default function MoverListWithFilters({
       pc:mt-[32px] pc:gap-[48px]`,
   };
 
-  // 임시. 테스트 - 아직 수정 안됨
-  console.log("==================== data ====================");
-  console.log(data);
-
   const moverInfos = data?.pages
     ?.flatMap((page) => page.list)
     ?.map((mover) => (
@@ -257,8 +253,6 @@ export default function MoverListWithFilters({
     if (newService === 99) {
       newService = null;
     }
-
-    console.log("newService :", newService);
 
     setFormState((prev) => ({
       ...prev,
@@ -285,10 +279,6 @@ export default function MoverListWithFilters({
       currentSort: sorts[newSort],
     }));
   };
-
-  useEffect(() => {
-    console.log("FormState updated:", formState);
-  }, [formState]);
 
   useEffect(() => {
     const handler = setTimeout(() => {

--- a/src/app/(user)/find-mover/page.tsx
+++ b/src/app/(user)/find-mover/page.tsx
@@ -1,14 +1,24 @@
-import MoverList from "./moverList";
+import { cookies } from "next/headers";
 
+import MoverList from "./moverList";
 import { getMoverList } from "@/api/mover";
 
 import { MOVER_DEFAULT_PAGE_SIZE } from "@/variables/mover";
 
 export default async function FindMoverList() {
-  const initialData = await getMoverList({
-    limit: MOVER_DEFAULT_PAGE_SIZE,
-    nextCursorId: null,
-  });
+  try {
+    const cookieStore = await cookies();
+    const cookie = `accessToken=${cookieStore.get("accessToken")?.value}`;
 
-  return <MoverList initialData={initialData} />;
+    const initialData = await getMoverList({
+      cookie: cookie,
+      limit: MOVER_DEFAULT_PAGE_SIZE,
+      nextCursorId: null,
+    });
+
+    return <MoverList initialData={initialData} />;
+  } catch (error) {
+    console.error("getMoverList Error:", error);
+    return <div>Error Loading Data</div>;
+  }
 }

--- a/src/components/layout/GNB.tsx
+++ b/src/components/layout/GNB.tsx
@@ -159,7 +159,7 @@ const GNB = () => {
             </div>
           ) : (
             <Link
-              href="auth/login"
+              href="/auth/login"
               className="block mt-8 mb-6 px-6 py-3 bg-pr-blue-300 text-white rounded-lg font-medium hover:bg-primary/90 text-center"
             >
               로그인

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -56,6 +56,7 @@ export interface GetMovingRequestListByMoverResponseData {
 }
 
 export interface GetMovingRequestListByMoverParamData {
+  cookie?: string;
   smallMove: boolean;
   houseMove: boolean;
   officeMove: boolean;


### PR DESCRIPTION
#### 추가사항

**참고 issue:**

- [x] SSR 에서 사용하는 API 2개에 쿠키 설정 추가
- [x] find-mover,  request 페이지에서 사용되는 useInfiniteQuery의 항시 개 데이터 호출 옵션 추가
- [ ] SSR 환경에서 호출되는 API에서 token이 만료되었을 경우 처리 로직 추가

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

#### 테스트 완료 여부

(에러 유무 테스트)

- [x] npm run dev

#### 스크린샷

#### 추가 코멘트

useInfiniteQuery를 사용한 무한 스크롤 코드에서 queryKey로 설정된 상태 변수의 변화를 간헐적으로 인지 못하는 현상이 발생하여,  새 데이터를 호출하는 옵션(staleTime : 0)을 추가하였습니다. 추후 더 나은 방향의 개선 방법을 알게되면 다시 수정해두겠습니다.
SSR 환경에서 accessToken을 가져와 전송하는 로직이 추가되어 있으나, accessToken이 만료된 경우, refreshToken을 가져와 토큰을 재발급하는 로직은 아직 추가되지 않았습니다.(개인 백엔드에 토큰 정보를 수정하여 테스트를 진행하여 반영할 예정입니다)