### PR TITLE
[김현우] (Datepicker, 견적 요청, 내 견적 관리) 수정

### DIFF
--- a/src/api/movingRequest.ts
+++ b/src/api/movingRequest.ts
@@ -64,6 +64,12 @@ interface MovingRequestData {
   region: number;
 }
 
+interface ActiveRequestResponse {
+  id?: number;
+  activeRequest: boolean;
+  message: string;
+}
+
 const PATH = "/moving-requests";
 
 export const movingRequests = {
@@ -78,12 +84,34 @@ export const movingRequests = {
         throw new Error("ACTIVE_REQUEST_EXISTS");
       }
 
-      // 다른 에러는 로깅하고 전파
       console.error("Error creating moving request:", {
         error: error.response?.data || error.message,
         requestData: data,
       });
       throw error;
+    }
+  },
+
+  checkActive: async (): Promise<ActiveRequestResponse> => {
+    try {
+      const response = await axiosInstance.get<ActiveRequestResponse>(
+        `${PATH}/active`,
+        {
+          headers: {
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            Pragma: "no-cache",
+            Expires: "0",
+          },
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error("Error checking active request:", error);
+
+      return {
+        activeRequest: false,
+        message: "요청 확인 중 문제가 발생했습니다.",
+      };
     }
   },
 };
@@ -201,4 +229,11 @@ export async function getMovingRequestListByMover({
   }
 }
 
-export type { PendingQuotesResponse, Quote, Mover, MovingRequest, Rating };
+export type {
+  PendingQuotesResponse,
+  Quote,
+  Mover,
+  MovingRequest,
+  Rating,
+  ActiveRequestResponse,
+};

--- a/src/api/movingRequest.ts
+++ b/src/api/movingRequest.ts
@@ -82,7 +82,7 @@ export const movingRequests = {
     } catch (error: any) {
       const errorMessage = error.response?.data?.data?.message;
 
-      if (errorMessage === "활성중인 이사요청이 있습니다.") {
+      if (errorMessage === "활성중인 견적요청이 있습니다.") {
         throw new Error("ACTIVE_REQUEST_EXISTS");
       }
 

--- a/src/api/pendingQuote.ts
+++ b/src/api/pendingQuote.ts
@@ -101,6 +101,15 @@ export const fetchPendingQuotes = async (): Promise<PendingQuotesResponse> => {
     return response.data;
   } catch (error) {
     console.error("Error fetching pending quotes:", error);
+
+    // 404일 경우 빈 배열과 함께 totalCount도 반환
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return {
+        list: [],
+        totalCount: 0,
+      };
+    }
+
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
     throw new Error(`Failed to fetch pending quotes: ${errorMessage}`);

--- a/src/app/(request)/layout.tsx
+++ b/src/app/(request)/layout.tsx
@@ -19,7 +19,7 @@ export default function QuoteRequestLayout({
   return (
     <QuoteProgressProvider>
       {/* ProgressBar 영역 - sticky 적용 */}
-      <div className="sticky top-0 z-50 bg-white">
+      <div className="sticky top-0 z-5 bg-white">
         <div className="flex flex-col max-w-[1400px] font-semibold px-5 py-8 mx-auto gap-6">
           견적 요청
           <ProgressBar />

--- a/src/app/(request)/request/AddressSelectionField.tsx
+++ b/src/app/(request)/request/AddressSelectionField.tsx
@@ -62,7 +62,7 @@ export default function AddressSelectionField({
                 setCurrentType("from");
                 setIsModalOpen(true);
               }}
-              className="w-540px text-pr-blue-300 p-4 border font-semibold border-solid rounded-2xl border-pr-blue-300 rounded-lg cursor-pointer hover:bg-pr-blue-50 text-md pc:text-2lg placeholder-pr-blue-300"
+              className="w-540px text-pr-blue-300 p-4 border font-semibold border-solid rounded-2xl border-pr-blue-300 cursor-pointer hover:bg-pr-blue-50 text-md pc:text-2lg placeholder-pr-blue-300"
             />
           </div>
 
@@ -77,7 +77,7 @@ export default function AddressSelectionField({
                 setCurrentType("to");
                 setIsModalOpen(true);
               }}
-              className="w-540px text-pr-blue-300 p-4 border font-semibold border-solid rounded-2xl border-pr-blue-300 rounded-lg cursor-pointer hover:bg-pr-blue-50 text-md pc:text-2lg placeholder-pr-blue-300"
+              className="w-540px text-pr-blue-300 p-4 border font-semibold border-solid rounded-2xl border-pr-blue-300 cursor-pointer hover:bg-pr-blue-50 text-md pc:text-2lg placeholder-pr-blue-300"
             />
           </div>
         </div>
@@ -85,7 +85,7 @@ export default function AddressSelectionField({
 
       {isModalOpen && (
         <div className="fixed inset-0 bg-[#141414] bg-opacity-50 z-50 flex items-center justify-center">
-          <div className="bg-white px-8 py-6 rounded-[32px] w-full max-w-lg">
+          <div className="bg-white px-6 py-3 pc:px-8 pc:py-6 rounded-[32px] w-full max-w-lg">
             <h3 className="text-2xl font-semibold mb-10 flex justify-between">
               <div>
                 {currentType === "from" ? "출발지" : "도착지"}를 선택해주세요

--- a/src/app/(request)/request/Chatter.tsx
+++ b/src/app/(request)/request/Chatter.tsx
@@ -2,7 +2,7 @@
 
 import { toast } from "react-hot-toast";
 import { useRouter } from "next/navigation";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import ChatField from "@/components/common/ChatField";
 import DatePicker from "@/components/request/DatePicker";
@@ -105,15 +105,49 @@ const EstimateRequest: React.FC = () => {
   const [type, setType] = useState<string>("");
   const [date, setDate] = useState<Date | null>(null);
   const [addresses, setAddresses] = useState<Address>({ from: "", to: "" });
-  const [messages, setMessages] = useState<Message[]>([
-    {
-      type: "bot",
-      text: "몇 가지 정보만 알려주시면 최대 5개의 견적을 받을 수 있어요 😊",
-    },
-    { type: "bot", text: "이사 종류를 선택해 주세요." },
-  ]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const { step, setStep } = useQuoteProgress();
+
+  useEffect(() => {
+    const checkActiveRequest = async () => {
+      try {
+        const data = await movingRequests.checkActive();
+
+        if (data.activeRequest) {
+          setMessages([
+            {
+              type: "bot",
+              text: "이미 진행 중인 이사 요청이 있습니다.",
+            },
+          ]);
+          toast.error(data.message);
+        } else {
+          setMessages([
+            {
+              type: "bot",
+              text: "몇 가지 정보만 알려주시면 최대 5개의 견적을 받을 수 있어요 😊",
+            },
+            { type: "bot", text: "이사 종류를 선택해 주세요." },
+          ]);
+        }
+      } catch (error) {
+        console.error("Error checking active request:", error);
+        // 에러가 발생해도 견적 요청은 계속 진행할 수 있도록 함
+        setMessages([
+          {
+            type: "bot",
+            text: "몇 가지 정보만 알려주시면 최대 5개의 견적을 받을 수 있어요 😊",
+          },
+          { type: "bot", text: "이사 종류를 선택해 주세요." },
+        ]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkActiveRequest();
+  }, []);
 
   // Message Handlers
   const handleNextStep = (newMessages: Message[], delay = 500) => {
@@ -151,9 +185,27 @@ const EstimateRequest: React.FC = () => {
 
   const handleSubmit = async () => {
     try {
+      const activeCheck = await movingRequests.checkActive();
+
+      if (activeCheck.activeRequest) {
+        toast.error(activeCheck.message);
+        setMessages((prev) => [
+          ...prev,
+          {
+            type: "bot",
+            text: "이미 진행 중인 이사 요청이 있어 새로운 견적을 요청할 수 없습니다.",
+          },
+        ]);
+        return;
+      }
+
       const postData = transformDataForPost({ type, date, addresses });
       await movingRequests.create(postData);
       toast.success("이사 요청이 완료되었습니다!");
+
+      setTimeout(() => {
+        router.push("/");
+      }, 2000);
     } catch (error) {
       if (error instanceof Error && error.message === "ACTIVE_REQUEST_EXISTS") {
         toast.error("이미 진행 중인 이사 요청이 있습니다.");
@@ -163,6 +215,7 @@ const EstimateRequest: React.FC = () => {
       }
     }
   };
+
   const handleEdit = (editStep: number) => {
     setStep(editStep);
     const stepMessages = {
@@ -240,7 +293,7 @@ const EstimateRequest: React.FC = () => {
   };
 
   return (
-    <div className="w-full py-10">
+    <div className="w-full pb-4">
       <div className="my-4 space-y-4">
         <AnimatePresence>
           {messages.map((message, index) => (
@@ -270,7 +323,7 @@ const EstimateRequest: React.FC = () => {
                     radius="24px"
                   />
                 </div>
-                {message.type === "user" && (
+                {message.type === "user" && !isLoading && (
                   <div className="flex justify-end">
                     {message.text === type && (
                       <EditButton onClick={() => handleEdit(0)} />
@@ -288,19 +341,23 @@ const EstimateRequest: React.FC = () => {
           ))}
         </AnimatePresence>
 
-        {/* 스텝 컴포넌트 */}
+        {/* Only show step content if there's no active request */}
         <AnimatePresence mode="wait">
-          {messages[messages.length - 1]?.type === "bot" && !isLoading && (
-            <motion.div
-              key={`step-${step}`}
-              initial="initial"
-              animate="animate"
-              exit="exit"
-              variants={chatBubbleVariants}
-            >
-              <div className="flex justify-end">{renderStepContent()}</div>
-            </motion.div>
-          )}
+          {messages[messages.length - 1]?.type === "bot" &&
+            !isLoading &&
+            !messages[0]?.text?.includes(
+              "이미 진행 중인 이사 요청이 있습니다"
+            ) && (
+              <motion.div
+                key={`step-${step}`}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                variants={chatBubbleVariants}
+              >
+                <div className="flex justify-end">{renderStepContent()}</div>
+              </motion.div>
+            )}
         </AnimatePresence>
       </div>
     </div>

--- a/src/app/(request)/request/Chatter.tsx
+++ b/src/app/(request)/request/Chatter.tsx
@@ -118,7 +118,7 @@ const EstimateRequest: React.FC = () => {
           setMessages([
             {
               type: "bot",
-              text: "이미 진행 중인 이사 요청이 있습니다.",
+              text: "이미 진행 중인 견적 요청이 있습니다.",
             },
           ]);
           toast.error(data.message);
@@ -193,7 +193,7 @@ const EstimateRequest: React.FC = () => {
           ...prev,
           {
             type: "bot",
-            text: "이미 진행 중인 이사 요청이 있어 새로운 견적을 요청할 수 없습니다.",
+            text: "이미 진행 중인 견적 요청이 있어 새로운 견적을 요청할 수 없습니다.",
           },
         ]);
         return;
@@ -201,14 +201,14 @@ const EstimateRequest: React.FC = () => {
 
       const postData = transformDataForPost({ type, date, addresses });
       await movingRequests.create(postData);
-      toast.success("이사 요청이 완료되었습니다!");
+      toast.success("견적 요청이 완료되었습니다!");
 
       setTimeout(() => {
         router.push("/");
       }, 2000);
     } catch (error) {
       if (error instanceof Error && error.message === "ACTIVE_REQUEST_EXISTS") {
-        toast.error("이미 진행 중인 이사 요청이 있습니다.");
+        toast.error("이미 진행 중인 견적 요청이 있습니다.");
       } else {
         toast.error("요청 처리 중 문제가 발생했습니다.");
         console.error("Moving request error:", error);
@@ -346,7 +346,7 @@ const EstimateRequest: React.FC = () => {
           {messages[messages.length - 1]?.type === "bot" &&
             !isLoading &&
             !messages[0]?.text?.includes(
-              "이미 진행 중인 이사 요청이 있습니다"
+              "이미 진행 중인 견적 요청이 있습니다"
             ) && (
               <motion.div
                 key={`step-${step}`}

--- a/src/app/(user)/me/profile/page.tsx
+++ b/src/app/(user)/me/profile/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Profile from "@/components/forms/Profile";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";

--- a/src/app/(user)/my-quote/expiredRequests.tsx
+++ b/src/app/(user)/my-quote/expiredRequests.tsx
@@ -80,60 +80,99 @@ const MovingIcon = () => (
     />
   </div>
 );
+const StatusBadge = ({
+  movingDate,
+  isConfirmed,
+}: {
+  movingDate: string;
+  isConfirmed: boolean;
+}) => {
+  const now = new Date();
+  const moveDate = new Date(movingDate);
+  const isFuture = moveDate > now;
 
-const StatusBadge = ({ isConfirmed }: { isConfirmed: boolean }) => (
-  <div className="gap-1 rounded-xl py-1 px-2 text-pr-blue-300 items-center flex flex-row bg-pr-blue-100">
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 36 36"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
+  const getStatusText = () => {
+    if (isFuture) return "진행예정 요청";
+    if (isConfirmed) return "확정된 요청";
+    return "만료된 요청";
+  };
+
+  // 진행예정일 때는 녹색 계열 사용
+  const colorClasses = isFuture
+    ? "text-emerald-600 bg-emerald-50"
+    : "text-pr-blue-300 bg-pr-blue-100";
+
+  return (
+    <div
+      className={`gap-1 rounded-xl py-1 px-2 items-center flex flex-row ${colorClasses}`}
     >
-      <path
-        d="M7 26L7.15928 25.6525C7.9634 23.898 8.45024 22.015 8.59724 20.0907L9.12162 13.226C9.47615 8.58495 13.3454 5 18 5V5C22.6546 5 26.5239 8.58495 26.8784 13.226L27.4028 20.0907C27.5498 22.015 28.0366 23.898 28.8407 25.6525L29 26"
-        stroke="#1B92FF"
-        strokeWidth="2"
-      />
-      <path
-        d="M29 26H7L9 21L10 11L12.5 6.5L18 5L23 6.5L26 11L27 21L29 26Z"
-        fill="#1B92FF"
-      />
-      <path
-        d="M7 26L29 26"
-        stroke="#1B92FF"
-        strokeWidth="2"
-        strokeLinecap="round"
-      />
-      <path
-        d="M21 29C21 30.6569 19.6569 32 18 32C16.3431 32 15 30.6569 15 29"
-        stroke="#1B92FF"
-        strokeWidth="2"
-      />
-    </svg>
-    {isConfirmed ? "확정된 요청" : "만료된 요청"}
-  </div>
-);
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 36 36"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M7 26L7.15928 25.6525C7.9634 23.898 8.45024 22.015 8.59724 20.0907L9.12162 13.226C9.47615 8.58495 13.3454 5 18 5V5C22.6546 5 26.5239 8.58495 26.8784 13.226L27.4028 20.0907C27.5498 22.015 28.0366 23.898 28.8407 25.6525L29 26"
+          stroke={isFuture ? "#059669" : "#1B92FF"}
+          strokeWidth="2"
+        />
+        <path
+          d="M29 26H7L9 21L10 11L12.5 6.5L18 5L23 6.5L26 11L27 21L29 26Z"
+          fill={isFuture ? "#059669" : "#1B92FF"}
+        />
+        <path
+          d="M7 26L29 26"
+          stroke={isFuture ? "#059669" : "#1B92FF"}
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <path
+          d="M21 29C21 30.6569 19.6569 32 18 32C16.3431 32 15 30.6569 15 29"
+          stroke={isFuture ? "#059669" : "#1B92FF"}
+          strokeWidth="2"
+        />
+      </svg>
+      {getStatusText()}
+    </div>
+  );
+};
 
 const RequestDetails = ({ request }: { request: MovingRequest }) => {
   const movingDate = new Date(request.movingDate);
   const weekDays = ["일", "월", "화", "수", "목", "금", "토"];
+  const now = new Date();
+  const isFuture = movingDate > now;
+
+  const formatDateTime = (date: Date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+
+    return `${year}. ${month}. ${day}. ${hours}시 ${minutes}분`;
+  };
 
   return (
     <div className="flex flex-col gap-3 text-lg font-medium text-left">
       <div className="flex flex-col pc:flex-row items-start pc:items-center gap-1 pc:gap-3">
-        <StatusBadge isConfirmed={request.isConfirmed} />
+        <StatusBadge
+          movingDate={request.movingDate}
+          isConfirmed={request.isConfirmed}
+        />
       </div>
 
       <div className="text-lg tablet:text-xl pc:text-2xl text-gray-500">
-        {movingDate.toLocaleDateString()} ({weekDays[movingDate.getDay()]})에
-        진행한 무빙
+        {formatDateTime(movingDate)} ({weekDays[movingDate.getDay()]})에
+        {isFuture ? " 진행 예정인 무빙" : " 진행한 무빙"}
       </div>
 
       <div className="flex flex-col gap-1">
         <DetailRow
           label="견적 요청일"
-          value={new Date(request.requestDate).toLocaleDateString()}
+          value={formatDateTime(new Date(request.requestDate))}
         />
         <DetailRow
           label="서비스"

--- a/src/app/(user)/my-quote/expiredRequests.tsx
+++ b/src/app/(user)/my-quote/expiredRequests.tsx
@@ -426,12 +426,14 @@ const ExpiredRequests = () => {
               </button>
 
               <div
-                className={`overflow-hidden transition-all duration-500 ease-in-out ${
+                className={`overflow-y-scroll transition-all duration-500 ease-in-out ${
                   openSection === request.id ? "max-h-[670px]" : "max-h-0"
                 }`}
               >
                 <div className="px-6 py-4 flex justify-between items-center border-t border-b border-gray-100">
-                  <div className="text-gray-500">견적서 필터</div>
+                  <div className="text-gray-400 text-xl font-semibold">
+                    견적서 보기
+                  </div>
                   <QuoteFilterDropdown
                     onSelect={(code) => handleFilterChange(request.id, code)}
                     disabled={loading}

--- a/src/app/(user)/my-quote/page.tsx
+++ b/src/app/(user)/my-quote/page.tsx
@@ -175,7 +175,7 @@ const MyQuotePage = () => {
             </ul>
           ) : (
             <div className="flex justify-center items-center min-h-[200px] text-gray-500">
-              활성중인 이사요청이 없습니다.
+              받은 견적이 없습니다.
             </div>
           )}
         </>

--- a/src/app/(user)/my-quote/page.tsx
+++ b/src/app/(user)/my-quote/page.tsx
@@ -88,10 +88,13 @@ const MyQuotePage = () => {
         setQuotes(list);
         setErrorMessage(null);
       } catch (error: any) {
+        console.log("Error object structure:", JSON.stringify(error, null, 2));
         console.error("Error fetching quotes:", error);
-        if (error.response?.status === 404) {
+
+        // Axios 에러의 경우 status code로 체크
+        if (error.name === "AxiosError" && error.response?.status === 404) {
           setQuotes([]);
-          setErrorMessage(null);
+          setErrorMessage(null); // 404는 정상적인 "데이터 없음" 상태로 처리
         } else {
           setErrorMessage("견적 정보를 불러오는데 실패했습니다.");
         }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,9 +5,9 @@ import Image from "next/image";
 
 export function NotFound404() {
   return (
-    <main className="min-h-[93vh] w-full flex items-center justify-center relative overflow-hidden">
+    <main className="h-[calc(100vh-88px)] w-full flex items-center justify-center relative overflow-hidden">
       <div className="relative z-10 text-center px-4 py-16 max-w-2xl mx-auto">
-        <div className="w-64 h-64 mx-auto mb-3 motion-safe:animate-bounce">
+        <div className="w-32 h-32 pc:w-64 pc:h-64 mx-auto mb-3 motion-safe:animate-bounce">
           <Image
             src={assets.images.movingTruck}
             alt="moving truck"

--- a/src/components/request/DatePicker.tsx
+++ b/src/components/request/DatePicker.tsx
@@ -12,6 +12,7 @@ interface DayInfo {
   isCurrentMonth?: boolean;
   isPrevMonth?: boolean;
   isNextMonth?: boolean;
+  isDisabled?: boolean;
 }
 
 interface DatePickerProps {
@@ -35,23 +36,39 @@ interface DatePickerProps {
  *
  * @returns {JSX.Element} 선택할 수 있는 날짜와 시간이 포함된 UI
  */
-
 const DatePicker: React.FC<DatePickerProps> = ({
   onChange,
   onComplete,
   initialDate = new Date(),
 }) => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0); // 시간을 00:00:00으로 설정하여 날짜만 비교
+
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1); // 기본값을 내일로 설정
+
   const [currentDate, setCurrentDate] = React.useState(
-    () => new Date(initialDate)
+    () => new Date(tomorrow)
   );
   const [selectedDate, setSelectedDate] = React.useState(
-    () => new Date(initialDate)
+    () => new Date(tomorrow)
   );
   const [step, setStep] = React.useState<Step>(DATE_STEP);
   const [selectedTime, setSelectedTime] = React.useState({
-    hours: initialDate.getHours(),
-    minutes: initialDate.getMinutes(),
+    hours: tomorrow.getHours(),
+    minutes: tomorrow.getMinutes(),
   });
+
+  // 선택할 수 있는 날짜인지 확인하는 함수
+  const isDisabled = (day: DayInfo): boolean => {
+    const selectedDay = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth(),
+      day.date
+    );
+    selectedDay.setHours(0, 0, 0, 0);
+    return selectedDay < tomorrow;
+  };
 
   const getDaysInMonth = React.useCallback((date: Date): DayInfo[] => {
     const year = date.getFullYear();
@@ -62,15 +79,25 @@ const DatePicker: React.FC<DatePickerProps> = ({
     const startingDay = firstDay.getDay();
     const prevMonthLastDay = new Date(year, month, 0).getDate();
 
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); // 오늘 날짜의 00:00로 초기화
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1); // 내일 날짜로 설정
+
     return [
       ...Array.from({ length: startingDay }, (_, i) => ({
         date: prevMonthLastDay - (startingDay - 1) + i,
         isPrevMonth: true,
       })),
-      ...Array.from({ length: daysInMonth }, (_, i) => ({
-        date: i + 1,
-        isCurrentMonth: true,
-      })),
+      ...Array.from({ length: daysInMonth }, (_, i) => {
+        const dayDate = new Date(year, month, i + 1);
+        const isDisabled = dayDate < tomorrow; // 내일 날짜 이전은 비활성화
+        return {
+          date: i + 1,
+          isCurrentMonth: true,
+          isDisabled, // 내일 이전 날짜는 비활성화
+        };
+      }),
       ...Array.from({ length: 42 - (startingDay + daysInMonth) }, (_, i) => ({
         date: i + 1,
         isNextMonth: true,
@@ -109,7 +136,8 @@ const DatePicker: React.FC<DatePickerProps> = ({
 
   const handleDateSelection = useCallback(
     (day: DayInfo) => {
-      if (day.isCurrentMonth) {
+      if (day.isCurrentMonth && !isDisabled(day)) {
+        // 비활성화된 날짜는 선택하지 않도록
         const newDate = new Date(
           currentDate.getFullYear(),
           currentDate.getMonth(),
@@ -177,7 +205,6 @@ const DatePicker: React.FC<DatePickerProps> = ({
       </h2>
     </div>
   );
-
   const DateGrid = React.memo(() => {
     const days = getDaysInMonth(currentDate);
 
@@ -195,6 +222,7 @@ const DatePicker: React.FC<DatePickerProps> = ({
 
           {days.map((day, index) => {
             const isSelected = isSelectedDate(day);
+            const disabled = isDisabled(day); // 날짜가 비활성화됐는지 확인
             return (
               <button
                 key={`day-${index}`}
@@ -205,8 +233,10 @@ const DatePicker: React.FC<DatePickerProps> = ({
                   "transition-colors duration-200",
                   !day.isCurrentMonth && "text-gray-300",
                   day.isCurrentMonth && "text-black hover:bg-gray-100",
-                  isSelected && "bg-blue-500 text-white hover:bg-blue-500"
+                  isSelected && "bg-blue-500 text-white hover:bg-blue-500",
+                  disabled && " text-gray-300 cursor-not-allowed" // 비활성화된 날짜 스타일
                 )}
+                disabled={disabled} // 비활성화된 날짜는 클릭되지 않도록
               >
                 {day.date}
               </button>

--- a/src/mocks/handlers/movingRequest.ts
+++ b/src/mocks/handlers/movingRequest.ts
@@ -19,7 +19,7 @@ export const movingRequestHandlers = [
           path: "/moving-requests/by-customer",
           method: "GET",
           message: "Not Found",
-          data: { message: "조건의 맞는 이사요청 목록이 없습니다." },
+          data: { message: "조건에 맞는 견적요청 목록이 없습니다." },
           date: new Date().toISOString(),
         },
         { status: 404 }


### PR DESCRIPTION
#### 수정사항

- checkActive로 이미 요청중인 견적이 있는 상태로 "견적 요청" 탭 접근시 "이미 진행 중인 이사 요청이 있습니다." 라는 메세지와 함께 toast popup을 띄움
- pendingQuotes가 없을 경우 백엔드에서 404에러 반환 관련, 404일경우 빈 배열과함께 totalcount : 0 을 반환하도록 수정하였음 (추후 문제가 될시 백엔드에 수정요청 의향있음)
- 견적 요청 완료 2초 후 랜딩페이지로 이동하도록 수정함
- Datepicker 무빙일을 견적요청 다음날부터 가능하도록 수정
- 내 견적 관리탭의 "대기중인 견적" 탭 텍스트를 "활성중인 이사요청이 없습니다." 에서 "받은 견적이 없습니다."로 수정
- 내 견적 관리탭의 "받았던 견적" 탭 배지를 "진행예정 요청", "만료된 요청", "확정된 요청" 으로 분리

(에러 유무 테스트)

- [x] 테스트 완료

#### 스크린샷

![image](https://github.com/user-attachments/assets/d8673f3e-2f8b-4736-bf88-f3849e6c9434)

![image](https://github.com/user-attachments/assets/701b5276-1438-407d-b3b7-10b1a9c6cc4e)

#### 진행예정

- 유저경험관련 추가적인 디자인수정 있을 수 있습니다!

#### 추가 코멘트

- 지속적으로 수정예정입니다, 문제발견시 말씀주세요
- 견적요청 이미 활성화된거 있을경우 저렇게 메세지로 피드백하는게 좋을까요 아니면 그냥 누른순간 이미 활성화된 요청있다고 모달로 띄워버리는게 좋을까요 ? 